### PR TITLE
Add note indicator icon with hover tooltip

### DIFF
--- a/backend/app/api/assignments.py
+++ b/backend/app/api/assignments.py
@@ -140,8 +140,8 @@ async def update_assignment(
         assignment.allocation_type = body.allocation_type
     if body.allocation_value is not None:
         assignment.allocation_value = body.allocation_value
-    if body.note is not None:
-        assignment.note = body.note
+    if "note" in body.model_fields_set:
+        assignment.note = body.note.strip() if body.note else None
 
     # Re-validate dates
     if assignment.start_date > assignment.end_date:

--- a/frontend/src/components/assignments/AssignmentModal.tsx
+++ b/frontend/src/components/assignments/AssignmentModal.tsx
@@ -128,7 +128,7 @@ export function AssignmentModal({
       end_date: endDate,
       allocation_type: allocationType,
       allocation_value: Number(allocationValue),
-      note: note || null,
+      note: note,
     };
 
     if (isEditing && assignment) {


### PR DESCRIPTION
## Summary
- StickyNote icon (Lucide) on assignment bars that have a note attached
- Hover tooltip showing note content (rendered via React portal to avoid overflow clipping)
- Fix: clearing note text now properly removes the note (backend + frontend)

## Test plan
- [ ] Add a note to an assignment → icon appears on the bar
- [ ] Hover over the icon → tooltip shows the note content
- [ ] Remove note text and save → icon disappears
- [ ] Drag & drop still works correctly with the icon present
- [ ] Resize assignment bars still works correctly