### PR TITLE
Feat: Add custom color picker for projects

### DIFF
--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -1,19 +1,36 @@
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
+
+HEX_COLOR_RE = re.compile(r"^#[0-9A-Fa-f]{6}$")
 
 
 class ProjectCreate(BaseModel):
     name: str
     color: str
 
+    @field_validator("color")
+    @classmethod
+    def validate_hex_color(cls, v: str) -> str:
+        if not HEX_COLOR_RE.match(v):
+            raise ValueError("color must be a valid hex color (#RRGGBB)")
+        return v.upper()
+
 
 class ProjectUpdate(BaseModel):
     name: Optional[str] = None
     color: Optional[str] = None
+
+    @field_validator("color")
+    @classmethod
+    def validate_hex_color(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not HEX_COLOR_RE.match(v):
+            raise ValueError("color must be a valid hex color (#RRGGBB)")
+        return v.upper() if v is not None else v
 
 
 class ProjectResponse(BaseModel):

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
         "react": "^19.2.0",
+        "react-colorful": "^5.6.1",
         "react-dom": "^19.2.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
@@ -8118,6 +8119,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "^19.2.0",
+    "react-colorful": "^5.6.1",
     "react-dom": "^19.2.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",

--- a/frontend/src/components/projects/ProjectForm.tsx
+++ b/frontend/src/components/projects/ProjectForm.tsx
@@ -9,6 +9,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { HexColorPicker } from "react-colorful";
+import { Pencil, Plus } from "lucide-react";
 import type { Project } from "@/api/projects";
 
 const COLOR_PALETTE = [
@@ -25,6 +27,27 @@ const COLOR_PALETTE = [
   "#EC4899",
   "#F43F5E",
 ];
+
+const HEX_COLOR_RE = /^#[0-9A-Fa-f]{6}$/;
+
+function isValidHex(v: string): boolean {
+  return HEX_COLOR_RE.test(v);
+}
+
+function getLuminance(hex: string): number {
+  const h = hex.replace("#", "");
+  if (h.length !== 6) return 0;
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+}
+
+function normalizeHexInput(value: string): string {
+  let v = value.startsWith("#") ? value : `#${value}`;
+  v = "#" + v.slice(1).replace(/[^0-9A-Fa-f]/g, "");
+  return v.slice(0, 7).toUpperCase();
+}
 
 interface ProjectFormProps {
   open: boolean;
@@ -43,16 +66,24 @@ export function ProjectForm({
 }: ProjectFormProps) {
   const [name, setName] = useState("");
   const [color, setColor] = useState(COLOR_PALETTE[0]);
+  const [hexInput, setHexInput] = useState(COLOR_PALETTE[0]);
+  const [showCustomPicker, setShowCustomPicker] = useState(false);
 
   useEffect(() => {
     if (project) {
       setName(project.name);
       setColor(project.color);
+      setHexInput(project.color);
+      setShowCustomPicker(!COLOR_PALETTE.includes(project.color));
     } else {
       setName("");
       setColor(COLOR_PALETTE[0]);
+      setHexInput(COLOR_PALETTE[0]);
+      setShowCustomPicker(false);
     }
   }, [project, open]);
+
+  const isCustomColor = !COLOR_PALETTE.includes(color);
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
@@ -85,7 +116,10 @@ export function ProjectForm({
                 <button
                   key={c}
                   type="button"
-                  onClick={() => setColor(c)}
+                  onClick={() => {
+                    setColor(c);
+                    setHexInput(c);
+                  }}
                   className={`h-8 w-8 rounded-full transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
                     color === c
                       ? "ring-2 ring-ring ring-offset-2"
@@ -96,7 +130,73 @@ export function ProjectForm({
                   aria-pressed={color === c}
                 />
               ))}
+              {/* Custom color toggle — circle with plus */}
+              <button
+                type="button"
+                onClick={() => setShowCustomPicker((prev) => !prev)}
+                className={`h-8 w-8 rounded-full transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 flex items-center justify-center ${
+                  isCustomColor
+                    ? "ring-2 ring-ring ring-offset-2"
+                    : showCustomPicker
+                      ? "border-2 border-dashed border-foreground text-foreground"
+                      : "border-2 border-dashed border-muted-foreground/50 text-muted-foreground/50 hover:border-foreground hover:text-foreground hover:scale-110"
+                }`}
+                style={
+                  isCustomColor
+                    ? { backgroundColor: color }
+                    : undefined
+                }
+                aria-label="Kolor niestandardowy"
+              >
+                {isCustomColor ? (
+                  <Pencil className="h-3.5 w-3.5" style={{ color: getLuminance(color) > 0.55 ? "#1a1a1a" : "#ffffff" }} />
+                ) : (
+                  <Plus className="h-4 w-4" />
+                )}
+              </button>
             </div>
+
+            {/* Custom color picker panel */}
+            {showCustomPicker && (
+              <div className="space-y-3 rounded-md border p-3">
+                <HexColorPicker
+                  color={color}
+                  onChange={(newColor) => {
+                    const upper = newColor.toUpperCase();
+                    setColor(upper);
+                    setHexInput(upper);
+                  }}
+                  style={{ width: "100%" }}
+                />
+                <div className="flex items-center gap-2">
+                  <span
+                    className="h-9 w-9 shrink-0 rounded-md border border-border"
+                    style={{
+                      backgroundColor: isValidHex(hexInput) ? hexInput : color,
+                    }}
+                  />
+                  <Input
+                    value={hexInput}
+                    onChange={(e) => {
+                      const normalized = normalizeHexInput(e.target.value);
+                      setHexInput(normalized);
+                      if (isValidHex(normalized)) {
+                        setColor(normalized);
+                      }
+                    }}
+                    onBlur={() => {
+                      if (!isValidHex(hexInput)) {
+                        setHexInput(color);
+                      }
+                    }}
+                    placeholder="#000000"
+                    maxLength={7}
+                    className="font-mono"
+                    aria-label="Kod koloru HEX"
+                  />
+                </div>
+              </div>
+            )}
           </div>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={onClose}>


### PR DESCRIPTION
Allow picking any hex color via a gradient picker (react-colorful) in addition to the existing 12-color preset palette. Includes hex text input with live validation and backend hex format validation.