### PR TITLE
docs: extract architecture, API, models & infra into docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,179 +1,28 @@
 # Workforce Planner
 
-## Opis projektu
+Internal web tool for IT workforce allocation planning (80+ employees). Replaces manual Excel tracking with an interactive timeline showing who works on what project, at what capacity, and for how long.
 
-Wewnętrzne narzędzie webowe do planowania obciążenia pracowników w firmie IT (80+ osób). Pozwala widzieć kto, na jakim projekcie, w jakim wymiarze i w jakim okresie pracuje. Zastępuje ręczne śledzenie alokacji w Excelu.
+## Documentation
 
-## Stack technologiczny
+Detailed docs live in `docs/` — read these when you need deeper context:
 
-### Backend
+- **[Architecture](docs/architecture.md)** — system design, component tree, frontend/backend structure, auth flow
+- **[Infrastructure](docs/infrastructure.md)** — Docker setup (dev + prod), env vars, deployment, scripts
+- **[API Reference](docs/api-reference.md)** — all endpoints, timeline contract, response formats
+- **[Data Models](docs/data-models.md)** — SQLAlchemy models, relationships, business rules, allocation logic
+- **[PRD](PRD.md)** — product requirements, user stories, success metrics
 
-- **Python 3.12+** z **FastAPI**
-- **SQLAlchemy 2.0** (async, ORM) + **Alembic** (migracje)
-- **PostgreSQL 16** (baza danych)
-- **Pydantic v2** (walidacja, schematy API)
-- **python-jose** + **passlib[bcrypt]** (JWT auth, hashing haseł)
-- **uvicorn** (serwer ASGI)
-- **httpx** (klient HTTP do integracji Calamari)
-- **pytest** + **pytest-asyncio** (testy)
+## Tech Stack
 
-### Frontend
+**Backend:** Python 3.12+ / FastAPI / SQLAlchemy 2.0 (async) / PostgreSQL 16 / Alembic / Pydantic v2
+**Frontend:** React 19 / TypeScript 5.x / Vite / Tailwind CSS 4 / shadcn/ui / TanStack Query v5 / TanStack Router / dnd-kit / Zustand / date-fns
 
-- **React 19** z **TypeScript 5.x**
-- **Vite** (bundler)
-- **Tailwind CSS 4** + **shadcn/ui** (komponenty UI)
-- **TanStack Query v5** (fetching, cache)
-- **TanStack Router** (routing)
-- **dnd-kit** (drag & drop, resize)
-- **date-fns** (operacje na datach, lokalizacja PL)
-- **Zustand** (lightweight state management)
-- **Vitest** + **Testing Library** (testy)
-
-## Struktura projektu
-
-```
-workforce-planner/
-├── backend/
-│   ├── app/
-│   │   ├── main.py                # FastAPI app, CORS, lifespan
-│   │   ├── config.py              # Settings (Pydantic BaseSettings)
-│   │   ├── database.py            # Async engine, session factory
-│   │   ├── models/                # SQLAlchemy models
-│   │   │   ├── user.py            # User (login accounts)
-│   │   │   ├── employee.py        # Employee
-│   │   │   ├── project.py         # Project
-│   │   │   └── assignment.py      # Assignment
-│   │   ├── schemas/               # Pydantic schemas (request/response)
-│   │   │   ├── auth.py
-│   │   │   ├── employee.py
-│   │   │   ├── project.py
-│   │   │   └── assignment.py
-│   │   ├── api/                   # FastAPI routers
-│   │   │   ├── auth.py
-│   │   │   ├── employees.py
-│   │   │   ├── projects.py
-│   │   │   ├── assignments.py
-│   │   │   ├── calendar.py        # Endpoint do timeline data
-│   │   │   └── holidays.py        # Święta polskie
-│   │   ├── services/              # Business logic
-│   │   │   ├── auth_service.py
-│   │   │   ├── assignment_service.py  # Kalkulacja godzin, FTE
-│   │   │   ├── calendar_service.py    # Working days, holidays
-│   │   │   └── calamari_service.py    # Integracja Calamari
-│   │   ├── core/
-│   │   │   ├── security.py        # JWT, password hashing
-│   │   │   └── dependencies.py    # FastAPI dependencies (get_db, get_current_user)
-│   │   └── utils/
-│   │       ├── working_days.py    # Obliczanie dni roboczych
-│   │       └── polish_holidays.py # Lista świąt polskich
-│   ├── alembic/                   # Migracje bazy danych
-│   ├── tests/
-│   ├── alembic.ini
-│   └── requirements.txt
-├── frontend/
-│   ├── src/
-│   │   ├── main.tsx
-│   │   ├── App.tsx
-│   │   ├── api/                   # API client (fetch wrappers)
-│   │   │   ├── client.ts          # Base fetch z JWT interceptor
-│   │   │   ├── auth.ts
-│   │   │   ├── employees.ts
-│   │   │   ├── projects.ts
-│   │   │   └── assignments.ts
-│   │   ├── components/
-│   │   │   ├── ui/                # shadcn/ui components
-│   │   │   ├── layout/
-│   │   │   │   ├── Sidebar.tsx
-│   │   │   │   └── Layout.tsx
-│   │   │   ├── auth/
-│   │   │   │   └── LoginForm.tsx
-│   │   │   ├── employees/
-│   │   │   │   ├── EmployeeList.tsx
-│   │   │   │   └── EmployeeForm.tsx
-│   │   │   ├── projects/
-│   │   │   │   ├── ProjectList.tsx
-│   │   │   │   └── ProjectForm.tsx
-│   │   │   ├── assignments/
-│   │   │   │   └── AssignmentModal.tsx
-│   │   │   └── timeline/
-│   │   │       ├── Timeline.tsx           # Główny komponent
-│   │   │       ├── TimelineHeader.tsx     # Nagłówki dat
-│   │   │       ├── TimelineRow.tsx        # Wiersz pracownika
-│   │   │       ├── TimelineBar.tsx        # Pasek assignmentu (draggable, resizable)
-│   │   │       ├── TimelineFilters.tsx    # Filtry zespołów, przełącznik widoków
-│   │   │       └── UtilizationBadge.tsx   # Badge z % obłożenia
-│   │   ├── hooks/
-│   │   │   ├── useAssignments.ts
-│   │   │   ├── useTimeline.ts
-│   │   │   └── useWorkingDays.ts
-│   │   ├── stores/
-│   │   │   └── timelineStore.ts   # Zustand: viewMode, filters, dateRange
-│   │   ├── lib/
-│   │   │   ├── workingDays.ts     # Kalkulacja dni roboczych (mirror backendu)
-│   │   │   └── utils.ts
-│   │   └── types/
-│   │       └── index.ts           # Shared TypeScript types
-│   ├── index.html
-│   ├── vite.config.ts
-│   ├── tailwind.config.ts
-│   ├── tsconfig.json
-│   └── package.json
-├── docker-compose.yml             # PostgreSQL + backend + frontend
-├── CLAUDE.md                      # Ten plik
-└── PRD.md                         # Dokument wymagań
-```
-
-## Modele danych (SQLAlchemy)
-
-```
-User: id, email, password_hash, full_name, role(admin|user), is_active, failed_login_attempts, locked_until, created_at
-Employee: id, first_name, last_name, team(enum: nullable), is_deleted, created_at
-Project: id, name(unique), color, is_deleted, created_at
-Assignment: id, employee_id(FK), project_id(FK), start_date, end_date, allocation_type(enum: percentage|monthly_hours|total_hours), allocation_value(Decimal), note, created_at, updated_at
-```
-
-## Kluczowe reguły biznesowe
-
-- 1 FTE = 100% = 8h/dzień × dni robocze w miesiącu
-- Minimalna jednostka: 1h (nie minuty)
-- Pracujemy pon-pt; soboty i niedziele widoczne ale bez assignmentów
-- Tydzień zaczyna się od poniedziałku
-- Alokacja procentowa: godziny_dziennie = 8 × (procent / 100)
-- Godziny miesięczne: godziny_dziennie = godziny_msc / dni_robocze_w_msc
-- Przy niepełnym miesiącu w assignmencie: godziny proporcjonalnie do dni roboczych w tym okresie
-- Obłożenie > 100% FTE = czerwone wyróżnienie, ale system NIE blokuje
-- Święta polskie (stałe + ruchome) pomniejszają dni robocze
-- Usunięty pracownik z aktywnymi assignmentami: ostrzeżenie, przyszłe assignmenty usuwane, historyczne archiwizowane (soft delete + flag)
-- Usunięty projekt: kaskadowe usunięcie assignmentów (po potwierdzeniu)
-
-## Konwencje kodu
-
-### Backend (Python)
-
-- Async everywhere (async def, await)
-- Type hints na wszystkich funkcjach
-- Pydantic models dla request/response (nie dict)
-- Dependency injection przez FastAPI Depends()
-- Nazwy endpointów: RESTful (GET /api/employees, POST /api/assignments, PATCH /api/assignments/{id})
-- Statusy HTTP: 200, 201, 204, 400, 401, 403, 404, 409, 422
-- Error responses: {"detail": "message"}
-- Docstrings na service functions
-
-### Frontend (TypeScript/React)
-
-- Strict TypeScript (no `any`)
-- Functional components + hooks only
-- TanStack Query do WSZYSTKICH operacji API (queries + mutations)
-- Colocation: komponent + hook + types w tym samym katalogu gdy specyficzne
-- CSS: wyłącznie Tailwind utility classes + shadcn/ui
-- Nazewnictwo: PascalCase komponenty, camelCase funkcje, SCREAMING_SNAKE stałe
-
-## Polecenia dev
+## Dev Commands
 
 ```bash
 # Backend
 cd backend && pip install -r requirements.txt
-uvicorn app.main:app --reload --port 8000
+uvicorn app.main:app --reload --port 8001
 
 # Frontend
 cd frontend && npm install
@@ -183,76 +32,42 @@ npm run dev  # port 5173
 docker compose up -d db
 cd backend && alembic upgrade head
 
-# Testy
+# All services (Docker)
+docker compose up -d
+
+# Tests
 cd backend && pytest
 cd frontend && npm run test
 ```
 
-## API Endpoints (szkic)
+## Code Conventions
 
-```
-POST   /api/auth/login          # Login, zwraca JWT
-POST   /api/auth/refresh        # Refresh token
+### Backend (Python)
 
-GET    /api/employees           # Lista (z filtrowaniem po team)
-POST   /api/employees           # Dodaj
-PATCH  /api/employees/{id}      # Edytuj
-DELETE /api/employees/{id}      # Usuń (soft delete)
+- Async everywhere (async def, await)
+- Type hints on all functions
+- Pydantic models for request/response (not dict)
+- Dependency injection via FastAPI Depends()
+- RESTful endpoints (GET /api/employees, POST /api/assignments, PATCH /api/assignments/{id})
+- HTTP status codes: 200, 201, 204, 400, 401, 403, 404, 409, 422
+- Error responses: `{"detail": "message"}`
+- Docstrings on service functions
 
-GET    /api/projects            # Lista
-POST   /api/projects            # Dodaj
-PATCH  /api/projects/{id}       # Edytuj
-DELETE /api/projects/{id}       # Usuń
+### Frontend (TypeScript/React)
 
-GET    /api/assignments                    # Lista (filtry: employee_id, project_id, date_from, date_to)
-GET    /api/assignments/timeline           # Dane do timeline (zakres dat, filtr team)
-POST   /api/assignments                    # Utwórz
-PATCH  /api/assignments/{id}               # Edytuj (w tym zmiana pracownika przez D&D)
-DELETE /api/assignments/{id}               # Usuń
+- Strict TypeScript (no `any`)
+- Functional components + hooks only
+- TanStack Query for ALL API operations (queries + mutations)
+- Colocation: component + hook + types in same directory when specific
+- CSS: exclusively Tailwind utility classes + shadcn/ui
+- Naming: PascalCase components, camelCase functions, SCREAMING_SNAKE constants
 
-GET    /api/calendar/working-days          # Dni robocze w zakresie dat
-GET    /api/calendar/holidays/{year}       # Święta polskie
-GET    /api/calendar/vacations             # Urlopy z Calamari (P1)
-```
+## Key Business Rules
 
-## Timeline endpoint — kontrakt
-
-`GET /api/assignments/timeline?start_date=2026-01-01&end_date=2026-06-30&teams=Frontend,Backend`
-
-Response:
-```json
-{
-  "employees": [
-    {
-      "id": 1,
-      "name": "Kowalski Jan",
-      "team": "Frontend",
-      "assignments": [
-        {
-          "id": 10,
-          "project_id": 5,
-          "project_name": "Projekt Alpha",
-          "project_color": "#3B82F6",
-          "start_date": "2026-01-15",
-          "end_date": "2026-03-31",
-          "allocation_type": "percentage",
-          "allocation_value": 50,
-          "note": "Lead developer",
-          "daily_hours": 4.0
-        }
-      ],
-      "utilization": {
-        "2026-01": { "percentage": 75, "hours": 126, "available_hours": 168, "is_overbooked": false },
-        "2026-02": { "percentage": 110, "hours": 176, "available_hours": 160, "is_overbooked": true }
-      }
-    }
-  ],
-  "holidays": [
-    {"date": "2026-01-01", "name": "Nowy Rok"},
-    {"date": "2026-01-06", "name": "Trzech Króli"},
-    {"date": "2026-05-01", "name": "Święto Pracy"},
-    {"date": "2026-05-03", "name": "Święto Konstytucji 3 Maja"}
-  ],
-  "working_days_per_month": { "2026-01": 21, "2026-02": 20, "2026-03": 22 }
-}
-```
+- 1 FTE = 100% = 8h/day x working days/month
+- Working days: Mon-Fri minus Polish public holidays (13/year)
+- Overbooking > 100% = red warning, but system does NOT block
+- Percentage allocation: `daily_hours = 8 x (percent / 100)`
+- Monthly hours: `daily_hours = monthly_hours / working_days_in_month`
+- Partial month: hours proportional to working days in that period
+- Soft delete for employees and projects; hard delete for assignments

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,234 @@
+# API Reference
+
+Base URL: `/api`
+
+All endpoints (except login and health) require `Authorization: Bearer <jwt_token>` header.
+
+## Health
+
+```
+GET    /api/health                          # Health check
+```
+
+## Authentication
+
+```
+POST   /api/auth/login                      # Returns JWT access + refresh token (201)
+POST   /api/auth/refresh                    # Refresh access token using refresh token (201)
+GET    /api/auth/me                         # Current user info (200)
+PATCH  /api/auth/me/theme                   # Update user theme preference (200)
+POST   /api/auth/reset-password-request     # Request password reset (token logged to console in dev)
+POST   /api/auth/reset-password             # Reset password with token
+```
+
+Login response includes `access_token`, `refresh_token`, and `token_type: "bearer"`.
+
+## Employees
+
+```
+GET    /api/employees                       # List employees (filter: ?team=Frontend&search=name)
+POST   /api/employees                       # Create employee (201)
+PATCH  /api/employees/{id}                  # Update employee (200)
+DELETE /api/employees/{id}                  # Soft delete (200, see below)
+```
+
+**Delete behavior:** If the employee has active assignments and `?confirm=true` is not passed, returns 200 with:
+```json
+{
+  "has_active_assignments": true,
+  "active_assignments_count": 3,
+  "active_assignments": [{"id": 1, "project_id": 5, "start_date": "...", "end_date": "..."}],
+  "message": "Employee has active assignments. Pass ?confirm=true to proceed."
+}
+```
+On successful deletion: `{"deleted": true}` (200).
+
+## Projects
+
+```
+GET    /api/projects                        # List projects (200)
+POST   /api/projects                        # Create project, unique name (201)
+PATCH  /api/projects/{id}                   # Update project (200)
+DELETE /api/projects/{id}                   # Delete with cascade (200, see below)
+```
+
+**Delete behavior:** Same two-step pattern as employees — returns active assignment info if `?confirm=true` is not passed.
+
+## Assignments
+
+```
+GET    /api/assignments                     # List (filters: employee_id, project_id, date_from, date_to)
+POST   /api/assignments                     # Create assignment (201)
+PATCH  /api/assignments/{id}                # Update (dates, allocation, employee) (200)
+POST   /api/assignments/{id}/split          # Split assignment at a given date (200)
+POST   /api/assignments/{id}/duplicate      # Duplicate an assignment (201)
+DELETE /api/assignments/{id}                # Delete assignment (204)
+```
+
+Assignment response includes: `id`, `employee_id`, `project_id`, `project_name`, `project_color`, `start_date`, `end_date`, `allocation_type`, `allocation_value`, `daily_hours`, `note`, `is_tentative`, `created_at`.
+
+## Users (Admin)
+
+```
+GET    /api/users                           # List all users (200)
+POST   /api/users                           # Create user (201)
+PATCH  /api/users/{id}                      # Update user (200)
+DELETE /api/users/{id}                      # Delete user (204)
+```
+
+## Settings
+
+```
+GET    /api/settings/calamari               # Get Calamari configuration status (200)
+PUT    /api/settings/calamari               # Update Calamari configuration (200)
+DELETE /api/settings/calamari               # Remove Calamari configuration (200)
+```
+
+## Calendar
+
+```
+GET    /api/calendar/holidays/{year}        # Polish holidays [{date, name}] (200)
+GET    /api/calendar/working-days           # Working days in date range (200)
+GET    /api/calendar/vacations              # Vacations from Calamari (200)
+POST   /api/calendar/vacations/sync         # Trigger manual vacation sync (200)
+```
+
+## Timeline Endpoint
+
+The main data endpoint powering the timeline view.
+
+### Request
+
+```
+GET /api/assignments/timeline?start_date=2026-01-01&end_date=2026-06-30&teams=Frontend,Backend&search=Kowalski
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `start_date` | date | yes | Range start (YYYY-MM-DD) |
+| `end_date` | date | yes | Range end (YYYY-MM-DD) |
+| `teams` | string | no | Comma-separated team filter |
+| `search` | string | no | Filter employees by first/last name |
+
+### Response
+
+```json
+{
+  "employees": [
+    {
+      "id": 1,
+      "name": "Kowalski Jan",
+      "team": "Frontend",
+      "assignments": [
+        {
+          "id": 10,
+          "project_id": 5,
+          "project_name": "Projekt Alpha",
+          "project_color": "#3B82F6",
+          "start_date": "2026-01-15",
+          "end_date": "2026-03-31",
+          "allocation_type": "percentage",
+          "allocation_value": 50,
+          "note": "Lead developer",
+          "is_tentative": false,
+          "daily_hours": 4.0
+        }
+      ],
+      "utilization": {
+        "2026-01": {
+          "percentage": 75,
+          "hours": 126,
+          "available_hours": 168,
+          "vacation_days": 0,
+          "is_overbooked": false
+        },
+        "2026-02": {
+          "percentage": 110,
+          "hours": 176,
+          "available_hours": 160,
+          "vacation_days": 2,
+          "is_overbooked": true
+        }
+      }
+    }
+  ],
+  "holidays": [
+    {"date": "2026-01-01", "name": "Nowy Rok"},
+    {"date": "2026-01-06", "name": "Trzech Króli"}
+  ],
+  "working_days_per_month": {
+    "2026-01": 21,
+    "2026-02": 20,
+    "2026-03": 22
+  },
+  "vacation_sync_status": {
+    "last_synced_at": "2026-04-07T14:30:00Z",
+    "is_configured": true
+  }
+}
+```
+
+### Response Fields
+
+**Employee object:**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | int | Employee ID |
+| `name` | string | "Last First" format |
+| `team` | string\|null | Team enum value |
+| `assignments` | array | Assignments within requested date range |
+| `utilization` | object | Per-month utilization keyed by "YYYY-MM" |
+
+**Assignment object (in timeline):**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | int | Assignment ID |
+| `project_id` | int | Project ID |
+| `project_name` | string | Project name |
+| `project_color` | string | Hex color |
+| `start_date` | date | Assignment start |
+| `end_date` | date | Assignment end |
+| `allocation_type` | enum | `percentage`, `monthly_hours`, or `total_hours` |
+| `allocation_value` | decimal | The raw allocation value |
+| `note` | string\|null | Optional note |
+| `is_tentative` | bool | Whether assignment is tentative |
+| `daily_hours` | float | Computed daily hours |
+
+**Utilization object (per month):**
+
+| Field | Type | Description |
+|---|---|---|
+| `percentage` | int | Sum of all assignment percentages |
+| `hours` | float | Total allocated hours |
+| `available_hours` | float | Working days x 8h |
+| `vacation_days` | int | Working days covered by vacations |
+| `is_overbooked` | bool | True if percentage > 100 |
+
+**Vacation sync status:**
+
+| Field | Type | Description |
+|---|---|---|
+| `last_synced_at` | datetime\|null | Last successful sync timestamp |
+| `is_configured` | bool | Whether Calamari integration is configured |
+
+## HTTP Status Codes
+
+| Code | Usage |
+|---|---|
+| 200 | Success (GET, PATCH, DELETE employees/projects) |
+| 201 | Created (POST login, POST create) |
+| 204 | Deleted (DELETE assignments, DELETE users) |
+| 400 | Bad request |
+| 401 | Unauthorized / invalid token |
+| 403 | Forbidden / insufficient role |
+| 404 | Resource not found |
+| 409 | Conflict (e.g. duplicate project name) |
+| 422 | Validation error (Pydantic) |
+
+## Error Response Format
+
+```json
+{"detail": "Human-readable error message"}
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,148 @@
+# Architecture
+
+## System Overview
+
+Workforce Planner is a full-stack web app for IT workforce allocation planning (~80+ employees). It replaces manual Excel-based tracking with an interactive timeline.
+
+```
+                    +-----------+
+                    |  Browser  |
+                    | (React)   |
+                    +-----+-----+
+                          |
+                   HTTP / WebSocket
+                          |
+               +----------+----------+
+               |    Vite Dev Server   |  (dev: port 5173)
+               |    Nginx             |  (prod: port 80)
+               +----------+----------+
+                          |
+                    /api/* proxy
+                          |
+               +----------+----------+
+               |   FastAPI Backend    |  (port 8001)
+               |   (uvicorn ASGI)    |
+               +----------+----------+
+                          |
+                 async SQLAlchemy
+                          |
+               +----------+----------+
+               |   PostgreSQL 16     |  (port 5433)
+               +---------------------+
+```
+
+## Frontend Architecture
+
+**React 19 + TypeScript 5.x + Vite**
+
+```
+frontend/src/
+├── api/              # Fetch wrappers with JWT interceptor
+│   ├── client.ts     # Base fetch — auto-attaches Bearer token, handles 401 refresh
+│   ├── auth.ts
+│   ├── employees.ts
+│   ├── projects.ts
+│   ├── assignments.ts
+│   ├── users.ts      # User management API
+│   └── settings.ts   # App settings API (Calamari config)
+├── components/
+│   ├── ui/           # shadcn/ui primitives (Button, Dialog, Select, etc.)
+│   ├── layout/       # Sidebar + Layout shell
+│   ├── auth/         # LoginForm with password reset
+│   ├── common/       # Shared components (TeamFilterChips)
+│   ├── employees/    # EmployeeList, EmployeeForm
+│   ├── projects/     # ProjectList, ProjectForm
+│   ├── users/        # UserManagement, UserFormDialog
+│   ├── settings/     # SettingsPage
+│   ├── assignments/  # AssignmentModal + form sub-components
+│   └── timeline/     # Core timeline components (see below)
+├── hooks/            # Custom hooks (useTimeline, useCrudList, useTeamSelection, useUserCrud, useDebouncedValue)
+├── stores/           # Zustand stores (authStore, timelineStore)
+├── lib/              # Utilities (workingDays.ts mirrors backend logic, utils.ts)
+└── types/            # Shared TypeScript types (index.ts)
+```
+
+### Timeline Component Tree
+
+```
+Timeline.tsx                      # Main container — orchestrates layout + data
+├── TimelineFilters.tsx           # Team multi-select, view mode toggle (monthly/weekly)
+├── TimelineHeader.tsx            # Date columns (months or weeks), holiday markers
+├── TimelineEmptyState.tsx        # Empty state when no employees match filters
+├── TimelineSummaryRow.tsx        # Aggregated summary row
+├── EmployeeUtilizationPanel.tsx  # Detailed utilization breakdown panel
+├── VacationDialog.tsx            # Vacation details dialog
+└── TimelineRow.tsx               # One row per employee — sticky name column
+    ├── UtilizationBadge.tsx      # Per-period % utilization (green/yellow/red)
+    └── TimelineBar.tsx           # Assignment bar — draggable (dnd-kit) + resizable edges
+```
+
+### State Management
+
+- **Server state**: TanStack Query v5 — all API calls go through queries/mutations with automatic cache invalidation
+- **Client state**: Zustand — timeline view mode, active filters, visible date range
+- **No prop drilling** — components read from query cache or Zustand store directly
+
+### Key Frontend Libraries
+
+| Library | Role |
+|---|---|
+| TanStack Query v5 | Server state, caching, optimistic updates |
+| TanStack Router | File-based routing |
+| dnd-kit | Drag & drop (move assignments between employees) + resize (change dates) |
+| date-fns | Date arithmetic with Polish locale |
+| Zustand | Lightweight client state |
+| shadcn/ui + Tailwind CSS 4 | UI components + styling |
+
+## Backend Architecture
+
+**FastAPI + async SQLAlchemy 2.0 + PostgreSQL 16**
+
+```
+backend/app/
+├── main.py             # FastAPI app factory, CORS, lifespan events
+├── config.py           # Pydantic BaseSettings (env vars)
+├── database.py         # Async engine + session factory
+├── models/             # SQLAlchemy ORM models (User, Employee, Project, Assignment, Vacation, AppSettings)
+├── schemas/            # Pydantic v2 request/response schemas
+├── api/                # FastAPI routers (auth, employees, projects, assignments, calendar, users, settings)
+├── services/           # Business logic layer
+│   ├── auth_service.py
+│   ├── assignment_service.py       # FTE/hours calculation engine
+│   ├── calamari_service.py         # External Calamari API integration
+│   └── vacation_sync_service.py    # Vacation sync logic
+├── core/
+│   ├── security.py     # JWT creation/verification, password hashing (bcrypt)
+│   ├── rate_limit.py   # Rate limiting
+│   └── dependencies.py # FastAPI Depends() — get_db session, get_current_user
+└── utils/
+    ├── working_days.py     # Working day calculations (Mon-Fri minus holidays)
+    └── polish_holidays.py  # 13 Polish holidays (9 fixed + 4 Easter-based)
+```
+
+### Request Flow
+
+1. Request hits FastAPI router (`api/`)
+2. Dependencies inject DB session + authenticated user (`core/dependencies.py`)
+3. Router delegates to service layer (`services/`)
+4. Service uses SQLAlchemy models for DB operations (`models/`)
+5. Response serialized via Pydantic schemas (`schemas/`)
+
+### Database Migrations
+
+Alembic manages schema migrations. Auto-run on backend startup in Docker.
+
+```bash
+cd backend && alembic upgrade head     # Apply migrations
+cd backend && alembic revision --autogenerate -m "description"  # Create migration
+```
+
+## Authentication Flow
+
+1. `POST /api/auth/login` — validates credentials, returns JWT access token + refresh token
+2. Frontend stores tokens in memory, attaches access token as `Authorization: Bearer <token>` via `client.ts` interceptor
+3. On 401, client automatically attempts `POST /api/auth/refresh` with refresh token; on failure, redirects to login
+4. Backend validates token via `get_current_user` dependency on every protected route
+5. Account lockout after 5 failed attempts (15 min cooldown)
+6. Password reset via token (logged to console in dev, email in prod)
+7. User roles: `admin`, `user`, `viewer`

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -1,0 +1,136 @@
+# Data Models & Business Rules
+
+## SQLAlchemy Models
+
+### User (login accounts)
+
+| Column | Type | Constraints |
+|---|---|---|
+| id | Integer | PK |
+| email | String | unique, not null |
+| password_hash | String | not null |
+| full_name | String | not null |
+| role | Enum | `admin` \| `user` \| `viewer` |
+| is_active | Boolean | default true |
+| failed_login_attempts | Integer | default 0 |
+| locked_until | DateTime | nullable |
+| theme | String | default "light" |
+| created_at | DateTime | auto |
+
+### Employee
+
+| Column | Type | Constraints |
+|---|---|---|
+| id | Integer | PK |
+| first_name | String | not null |
+| last_name | String | not null |
+| email | String | nullable, unique |
+| team | Enum | nullable — BA, Backend, DevOps, Frontend, ML, Mobile, PM, QA, UX_UI_Designer |
+| is_deleted | Boolean | default false (soft delete) |
+| created_at | DateTime | auto |
+
+### Project
+
+| Column | Type | Constraints |
+|---|---|---|
+| id | Integer | PK |
+| name | String | unique, not null |
+| color | String(7) | not null (hex color) |
+| is_deleted | Boolean | default false (soft delete) |
+| created_at | DateTime | auto |
+
+### Assignment
+
+| Column | Type | Constraints |
+|---|---|---|
+| id | Integer | PK |
+| employee_id | Integer | FK -> Employee |
+| project_id | Integer | FK -> Project |
+| start_date | Date | not null |
+| end_date | Date | not null |
+| allocation_type | Enum | `percentage` \| `monthly_hours` \| `total_hours` |
+| allocation_value | Numeric(7,2) | not null |
+| note | String | nullable |
+| is_tentative | Boolean | default false |
+| created_at | DateTime | auto |
+| updated_at | DateTime | auto on update |
+
+### Vacation (synced from Calamari)
+
+| Column | Type | Constraints |
+|---|---|---|
+| id | Integer | PK |
+| employee_id | Integer | nullable, indexed (not FK) |
+| employee_email | String | not null |
+| start_date | Date | not null |
+| end_date | Date | not null |
+| leave_type | String | not null |
+| calamari_id | String | unique, not null |
+| synced_at | DateTime | auto |
+
+### AppSettings (key-value config store)
+
+| Column | Type | Constraints |
+|---|---|---|
+| key | String | PK |
+| value | String | not null |
+| updated_at | DateTime | auto on update |
+
+## Relationships
+
+```
+User (standalone — login accounts, not linked to Employee)
+
+Employee  1 ──→ N  Assignment
+Project   1 ──→ N  Assignment
+
+Vacation.employee_id references Employee.id but is NOT a formal FK
+  (vacations are synced from external system, employee matching is best-effort)
+
+AppSettings (standalone — stores Calamari config etc.)
+```
+
+## Business Rules
+
+### FTE & Allocation
+
+- **1 FTE = 100% = 8h/day x working days in month**
+- Minimum unit: 1 hour (not minutes)
+- Working days: Mon-Fri, excluding Polish public holidays
+- Week starts on Monday (ISO standard)
+
+### Allocation Calculation
+
+| Type | Daily hours formula |
+|---|---|
+| Percentage | `8 x (percentage / 100)` |
+| Monthly hours | `monthly_hours / working_days_in_month` |
+| Partial month | Hours proportional to working days in the assignment's overlap with that month |
+
+### Overbooking
+
+- Utilization > 100% FTE = red highlight on timeline
+- System does **NOT** block overbooking — it only warns visually
+
+### Tentative Assignments
+
+- Assignments can be marked as `is_tentative` for planning purposes
+- Visually distinguished on timeline
+
+### Polish Holidays
+
+13 per year: 9 fixed dates + 4 Easter-based movable holidays. Holidays reduce working days in their month.
+
+### Vacation Integration
+
+- Vacations synced from Calamari API (manual or scheduled sync)
+- Vacation days reduce available hours in utilization calculations
+- `vacation_days` field in per-month utilization shows working days covered by vacations
+
+### Deletion Rules
+
+| Entity | Behavior |
+|---|---|
+| **Employee** | Soft delete. Warning if active assignments exist. Future assignments removed, historical archived. |
+| **Project** | Soft delete. Cascade deletes all linked assignments (after confirmation). |
+| **Assignment** | Hard delete. Supports split and duplicate operations. |

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -72,8 +72,8 @@
 
 | Column | Type | Constraints |
 |---|---|---|
-| key | String | PK |
-| value | String | not null |
+| key | String(255) | PK |
+| value | String(2000) | not null |
 | updated_at | DateTime | auto on update |
 
 ## Relationships

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -1,0 +1,140 @@
+# Infrastructure
+
+## Services
+
+| Service | Dev Port | Prod Port | Image/Build |
+|---|---|---|---|
+| **Frontend** | 5173 | 80 (via Traefik) | `./frontend` (Vite dev / Nginx prod) |
+| **Backend** | 8001 | 8001 (via Traefik) | `./backend` (uvicorn) |
+| **PostgreSQL** | 5433 | internal only | `postgres:16` |
+| **Traefik** | — | 80, 443 | `traefik:v3.6` (prod only) |
+
+## Docker Compose — Development
+
+`docker-compose.yml` — all-in-one local setup:
+
+```bash
+docker compose up -d          # Start all services
+docker compose up -d db       # Start only PostgreSQL
+docker compose logs -f backend  # Follow backend logs
+```
+
+- Backend hot-reloads via volume mount (`./backend/app` -> `/app/app`)
+- Frontend hot-reloads via volume mount (`./frontend/src` -> `/app/src`)
+- DB data persists in `pgdata` Docker volume
+- Migrations + admin user creation run automatically on backend startup
+
+### Dev Database Credentials
+
+| Variable | Value |
+|---|---|
+| Host | `localhost:5433` |
+| Database | `workforce_planner` |
+| User | `workforce` |
+| Password | `workforce_dev` |
+
+### Default Login
+
+| Field | Value |
+|---|---|
+| Email | `admin@workforce.local` |
+| Password | `Admin123!` |
+
+## Docker Compose — Production
+
+`docker-compose.prod.yml` — production setup with Traefik reverse proxy + Let's Encrypt TLS.
+
+### Prod Architecture
+
+```
+Internet
+  │
+  ├── :80  ──→ Traefik ──→ redirect to :443
+  └── :443 ──→ Traefik
+                ├── app.${DOMAIN}  ──→ Frontend (Nginx, port 80)
+                └── api.${DOMAIN}  ──→ Backend  (uvicorn, port 8001)
+                                          │
+                                          └──→ PostgreSQL (internal, port 5432)
+```
+
+### Required Environment Variables (prod)
+
+| Variable | Description |
+|---|---|
+| `DOMAIN` | Base domain (e.g. `workforce.example.com`) |
+| `ACME_EMAIL` | Email for Let's Encrypt certificate registration |
+| `POSTGRES_DB` | Database name |
+| `POSTGRES_USER` | Database user |
+| `POSTGRES_PASSWORD` | Database password |
+| `SECRET_KEY` | JWT signing key — **must be changed from default** |
+| `CORS_ORIGINS` | Allowed origins (e.g. `https://app.workforce.example.com`) |
+
+### Optional Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `ACCESS_TOKEN_EXPIRE_MINUTES` | `1440` (24h) | JWT access token lifetime |
+| `REFRESH_TOKEN_EXPIRE_MINUTES` | `10080` (7d) | JWT refresh token lifetime |
+| `ENVIRONMENT` | — | Environment name |
+| `RELOAD` | — | Enable uvicorn auto-reload (used in entrypoint.sh, set to "true" in dev compose) |
+
+Note: Calamari API configuration is managed via the `/api/settings/calamari` endpoint and stored in the AppSettings table, not via env vars. See `backend/.env.example` for a reference of all variables.
+
+### Prod Deployment
+
+```bash
+# Create .env with all required variables, then:
+docker compose -f docker-compose.prod.yml up -d
+```
+
+- Frontend uses `Dockerfile.prod` (multi-stage build → Nginx)
+- Traefik auto-provisions Let's Encrypt TLS certificates
+- TLS certs stored in `letsencrypt` Docker volume
+- No ports exposed directly — all traffic routed through Traefik
+
+## Manual Setup (without Docker)
+
+**Prerequisites:** Python 3.12+, Node.js 20+, Docker (for PostgreSQL only)
+
+```bash
+# 1. Start database
+docker compose up -d db
+
+# 2. Backend
+cd backend
+python3 -m venv venv
+source venv/bin/activate    # Windows: venv\Scripts\activate
+pip install -r requirements.txt
+alembic upgrade head
+python scripts/create_admin.py
+uvicorn app.main:app --reload --port 8001
+
+# 3. Frontend (new terminal)
+cd frontend
+npm install
+npm run dev
+```
+
+### Seed Demo Data
+
+```bash
+cd backend
+python scripts/seed_demo_data.py
+# Creates: 15 employees, 5 projects, 20 assignments
+```
+
+## Scripts
+
+| Script | Purpose |
+|---|---|
+| `backend/scripts/create_admin.py` | Create initial admin user |
+| `backend/scripts/seed_demo_data.py` | Seed demo employees, projects, assignments |
+
+## CI/CD
+
+Two GitHub Actions workflows in `.github/workflows/`:
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| `ci.yml` | PRs + pushes to main | Runs tests, type checking, linting, builds (Python 3.12, Node 20) |
+| `deploy.yml` | Pushes to main | Deploys to staging server |


### PR DESCRIPTION
## Summary

- **Slimmed down CLAUDE.md** from ~260 to ~65 lines — now contains only what's needed for daily coding (stack, conventions, dev commands, key business rules) with links to detailed docs
- **Created `docs/` directory** with 4 focused documents:
  - `architecture.md` — system diagram, frontend component tree, backend structure, auth flow
  - `api-reference.md` — all API endpoints with full request/response schemas
  - `data-models.md` — SQLAlchemy models, enums, relationships, business rules
  - `infrastructure.md` — Docker dev/prod setup, env vars, CI/CD, scripts
- **Verified all docs against actual codebase** and fixed discrepancies found in the original CLAUDE.md (missing routes, models, columns, enum values, etc.)

### Key fixes during verification
- Fixed non-existent `calendar_service.py` → actual `vacation_sync_service.py`
- Added 13 undocumented API routes (split, duplicate, users CRUD, settings, etc.)
- Added missing models (Vacation, AppSettings) and columns (User.theme, Employee.email, Assignment.is_tentative)
- Added missing enum values (viewer role, BA + ML teams)
- Fixed HTTP status codes (employee/project DELETE returns 200, not 204)
- Fixed Python version (3.12+, not 3.9+), Node (20+, not 18+)
- Added CI/CD documentation
