### PR TITLE
Feat: Project archiving — status filter, archive/unarchive actions

### DIFF
--- a/backend/app/api/assignments.py
+++ b/backend/app/api/assignments.py
@@ -101,14 +101,20 @@ async def create_assignment(
     if not emp.scalar_one_or_none():
         raise HTTPException(status_code=404, detail="Employee not found")
 
-    # Validate project exists
+    # Validate project exists and is not archived
     proj = await db.execute(
         select(Project).where(
             Project.id == body.project_id, Project.is_deleted == False
         )
     )
-    if not proj.scalar_one_or_none():
+    project = proj.scalar_one_or_none()
+    if not project:
         raise HTTPException(status_code=404, detail="Project not found")
+    if project.is_archived:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Nie można przypisać pracownika do zarchiwizowanego projektu",
+        )
 
     assignment = Assignment(
         employee_id=body.employee_id,
@@ -154,8 +160,14 @@ async def update_assignment(
                 Project.id == body.project_id, Project.is_deleted == False
             )
         )
-        if not proj.scalar_one_or_none():
+        project = proj.scalar_one_or_none()
+        if not project:
             raise HTTPException(status_code=404, detail="Project not found")
+        if project.is_archived:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Nie można przypisać pracownika do zarchiwizowanego projektu",
+            )
         assignment.project_id = body.project_id
 
     if body.start_date is not None:

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -21,12 +21,19 @@ router = APIRouter(prefix="/api/projects", tags=["projects"])
 async def list_projects(
     search: Optional[str] = Query(None),
     include_deleted: bool = Query(False),
+    status: str = Query("active"),
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(get_current_user),
 ):
     query = select(Project)
     if not include_deleted:
         query = query.where(Project.is_deleted == False)
+    if status == "archived":
+        query = query.where(Project.is_archived == True)
+    elif status == "all":
+        pass  # no filter — return both active and archived
+    else:  # "active" (default)
+        query = query.where(Project.is_archived == False)
     if search:
         query = query.where(Project.name.ilike(f"%{search}%"))
     query = query.order_by(Project.name)
@@ -135,3 +142,39 @@ async def delete_project(
 
     await db.commit()
     return {"deleted": True}
+
+
+@router.post("/{project_id}/archive", response_model=ProjectResponse)
+async def archive_project(
+    project_id: int,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_editor),
+):
+    result = await db.execute(select(Project).where(Project.id == project_id))
+    project = result.scalar_one_or_none()
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+    if project.is_deleted:
+        raise HTTPException(status_code=400, detail="Cannot archive a deleted project")
+
+    project.is_archived = True
+    await db.commit()
+    await db.refresh(project)
+    return project
+
+
+@router.post("/{project_id}/unarchive", response_model=ProjectResponse)
+async def unarchive_project(
+    project_id: int,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_editor),
+):
+    result = await db.execute(select(Project).where(Project.id == project_id))
+    project = result.scalar_one_or_none()
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    project.is_archived = False
+    await db.commit()
+    await db.refresh(project)
+    return project

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date
-from typing import Optional
+from typing import Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func as sa_func
@@ -21,7 +21,7 @@ router = APIRouter(prefix="/api/projects", tags=["projects"])
 async def list_projects(
     search: Optional[str] = Query(None),
     include_deleted: bool = Query(False),
-    status: str = Query("active"),
+    status: Literal["active", "archived", "all"] = Query("active"),
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(get_current_user),
 ):
@@ -173,6 +173,9 @@ async def unarchive_project(
     project = result.scalar_one_or_none()
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
+
+    if project.is_deleted:
+        raise HTTPException(status_code=400, detail="Cannot unarchive a deleted project")
 
     project.is_archived = False
     await db.commit()

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -28,12 +28,11 @@ async def list_projects(
     query = select(Project)
     if not include_deleted:
         query = query.where(Project.is_deleted == False)
-    if status == "archived":
-        query = query.where(Project.is_archived == True)
-    elif status == "all":
-        pass  # no filter — return both active and archived
-    else:  # "active" (default)
+    if status == "active":
         query = query.where(Project.is_archived == False)
+    elif status == "archived":
+        query = query.where(Project.is_archived == True)
+    # "all" — no filter
     if search:
         query = query.where(Project.name.ilike(f"%{search}%"))
     query = query.order_by(Project.name)

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -21,16 +21,16 @@ router = APIRouter(prefix="/api/projects", tags=["projects"])
 async def list_projects(
     search: Optional[str] = Query(None),
     include_deleted: bool = Query(False),
-    status: Literal["active", "archived", "all"] = Query("active"),
+    project_status: Literal["active", "archived", "all"] = Query("active", alias="status"),
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(get_current_user),
 ):
     query = select(Project)
     if not include_deleted:
         query = query.where(Project.is_deleted == False)
-    if status == "active":
+    if project_status == "active":
         query = query.where(Project.is_archived == False)
-    elif status == "archived":
+    elif project_status == "archived":
         query = query.where(Project.is_archived == True)
     # "all" — no filter
     if search:

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -13,4 +13,5 @@ class Project(Base):
     name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
     color: Mapped[str] = mapped_column(String(7), nullable=False)
     is_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
+    is_archived: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -38,6 +38,7 @@ class ProjectResponse(BaseModel):
     name: str
     color: str
     is_deleted: bool
+    is_archived: bool
     created_at: datetime
 
     model_config = {"from_attributes": True}

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -2,9 +2,14 @@ import { apiFetch } from "./client";
 import type { Project, ProjectCreateData } from "@/types/project";
 import type { DeleteResponse } from "@/types/common";
 
-export function fetchProjects(search?: string): Promise<Project[]> {
-  const qs = search ? `?search=${encodeURIComponent(search)}` : "";
-  return apiFetch<Project[]>(`/api/projects${qs}`);
+export function fetchProjects(
+  search?: string,
+  status: "active" | "archived" | "all" = "active",
+): Promise<Project[]> {
+  const params = new URLSearchParams();
+  if (search) params.set("search", search);
+  params.set("status", status);
+  return apiFetch<Project[]>(`/api/projects?${params.toString()}`);
 }
 
 export function createProject(data: ProjectCreateData): Promise<Project> {
@@ -26,10 +31,18 @@ export function updateProject(
 
 export function deleteProject(
   id: number,
-  confirm = false
+  confirm = false,
 ): Promise<DeleteResponse> {
   const params = confirm ? "?confirm=true" : "";
   return apiFetch<DeleteResponse>(`/api/projects/${id}${params}`, {
     method: "DELETE",
   });
+}
+
+export function archiveProject(id: number): Promise<Project> {
+  return apiFetch<Project>(`/api/projects/${id}/archive`, { method: "POST" });
+}
+
+export function unarchiveProject(id: number): Promise<Project> {
+  return apiFetch<Project>(`/api/projects/${id}/unarchive`, { method: "POST" });
 }

--- a/frontend/src/components/assignments/AssignmentModal.tsx
+++ b/frontend/src/components/assignments/AssignmentModal.tsx
@@ -42,11 +42,29 @@ export function AssignmentModal({
     enabled: open,
   });
 
-  const { data: projects = [] } = useQuery({
-    queryKey: ["projects"],
-    queryFn: () => fetchProjects(),
+  const { data: allProjects = [], status: activeProjectsStatus } = useQuery({
+    queryKey: ["projects", "active"],
+    queryFn: () => fetchProjects(undefined, "active"),
     enabled: open,
   });
+
+  const currentProjectId = assignment?.project_id;
+  const isCurrentProjectActive = allProjects.some((p) => p.id === currentProjectId);
+
+  // Only fetch archived projects when editing and the assigned project is not in the active list
+  const { data: archivedProjects = [] } = useQuery({
+    queryKey: ["projects", "archived"],
+    queryFn: () => fetchProjects(undefined, "archived"),
+    enabled:
+      open && isEditing && activeProjectsStatus === "success" && !isCurrentProjectActive,
+  });
+
+  const projects = isEditing
+    ? [
+        ...allProjects,
+        ...archivedProjects.filter((p) => p.id === currentProjectId),
+      ]
+    : allProjects;
 
   useEffect(() => {
     if (!open) return;

--- a/frontend/src/components/projects/ProjectList.tsx
+++ b/frontend/src/components/projects/ProjectList.tsx
@@ -1,22 +1,29 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { useCrudList } from "@/hooks/useCrudList";
-import { Pencil, Plus, Trash2 } from "lucide-react";
+import { Archive, ArchiveRestore, Pencil, Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { DataTable } from "@/components/ui/DataTable";
 import type { DataTableColumn } from "@/types/ui";
 import { SearchInput } from "@/components/ui/SearchInput";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { cn } from "@/lib/utils";
 import {
+  archiveProject,
   createProject,
   deleteProject,
   fetchProjects,
+  unarchiveProject,
   updateProject,
 } from "@/api/projects";
 import type { Project, ProjectCreateData } from "@/types/project";
 import { ProjectForm } from "./ProjectForm";
+import { toast } from "sonner";
+
+type StatusFilter = "active" | "archived" | "all";
 
 const PROJECT_COLUMNS: DataTableColumn<Project>[] = [
   {
@@ -25,16 +32,25 @@ const PROJECT_COLUMNS: DataTableColumn<Project>[] = [
     cell: (proj) => (
       <span className="flex items-center gap-2">
         <span
-          className="inline-block h-4 w-4 rounded"
+          className="inline-block h-4 w-4 shrink-0 rounded"
           style={{ backgroundColor: proj.color }}
         />
         {proj.name}
+        {proj.is_archived && (
+          <Badge variant="secondary" className="text-xs">
+            Zarchiwizowany
+          </Badge>
+        )}
       </span>
     ),
   },
 ];
 
 export function ProjectList() {
+  const queryClient = useQueryClient();
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("active");
+  const [archiveTarget, setArchiveTarget] = useState<Project | null>(null);
+
   const crud = useCrudList<Project, ProjectCreateData, Partial<ProjectCreateData>>({
     queryKey: ["projects"],
     createMutationFn: createProject,
@@ -49,10 +65,28 @@ export function ProjectList() {
 
   const [searchQuery, setSearchQuery] = useState("");
   const debouncedSearch = useDebouncedValue(searchQuery.trim(), 300);
-
   const { data: projects = [], isLoading } = useQuery({
-    queryKey: ["projects", debouncedSearch],
-    queryFn: () => fetchProjects(debouncedSearch || undefined),
+    queryKey: ["projects", debouncedSearch, statusFilter],
+    queryFn: () => fetchProjects(debouncedSearch || undefined, statusFilter),
+  });
+
+  const archiveMutation = useMutation({
+    mutationFn: (id: number) => archiveProject(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
+      toast.success("Projekt zarchiwizowany");
+      setArchiveTarget(null);
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const unarchiveMutation = useMutation({
+    mutationFn: (id: number) => unarchiveProject(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
+      toast.success("Projekt przywrócony");
+    },
+    onError: (err: Error) => toast.error(err.message),
   });
 
   const handleFormSubmit = (data: { name: string; color: string }) => {
@@ -67,7 +101,9 @@ export function ProjectList() {
     projects.length === 0
       ? debouncedSearch
         ? `Brak wyników dla „${searchQuery}"`
-        : "Brak projektów. Dodaj pierwszy."
+        : statusFilter === "archived"
+          ? "Brak zarchiwizowanych projektów."
+          : "Brak projektów. Dodaj pierwszy."
       : undefined;
 
   return (
@@ -82,13 +118,37 @@ export function ProjectList() {
         }
       />
 
-      <div className="mb-4">
+      <div className="mb-4 flex items-center gap-3">
         <SearchInput
           className="w-64"
           placeholder="Szukaj projektu..."
           value={searchQuery}
           onChange={setSearchQuery}
         />
+        <div className="flex items-center gap-1">
+          {(
+            [
+              { value: "all", label: "Wszystkie" },
+              { value: "active", label: "Aktywne" },
+              { value: "archived", label: "Zarchiwizowane" },
+            ] as { value: StatusFilter; label: string }[]
+          ).map(({ value, label }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setStatusFilter(value)}
+              className={cn(
+                "rounded-md border px-2 py-1 text-xs transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                statusFilter === value
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-muted",
+              )}
+              aria-pressed={statusFilter === value}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
       </div>
 
       <DataTable<Project>
@@ -105,6 +165,26 @@ export function ProjectList() {
             >
               <Pencil className="h-4 w-4" />
             </Button>
+            {proj.is_archived ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => unarchiveMutation.mutate(proj.id)}
+                disabled={unarchiveMutation.isPending}
+                aria-label={`Przywróć ${proj.name}`}
+              >
+                <ArchiveRestore className="h-4 w-4" />
+              </Button>
+            ) : (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setArchiveTarget(proj)}
+                aria-label={`Archiwizuj ${proj.name}`}
+              >
+                <Archive className="h-4 w-4" />
+              </Button>
+            )}
             <Button
               variant="ghost"
               size="sm"
@@ -127,6 +207,29 @@ export function ProjectList() {
         isSubmitting={
           crud.createMutation.isPending || crud.updateMutation.isPending
         }
+      />
+
+      <ConfirmDialog
+        open={archiveTarget !== null}
+        onOpenChange={(o) => !o && setArchiveTarget(null)}
+        title="Archiwizuj projekt"
+        description={
+          archiveTarget ? (
+            <>
+              Czy na pewno chcesz zarchiwizować projekt{" "}
+              <strong>{archiveTarget.name}</strong>? Istniejące assignmenty
+              pozostaną bez zmian, ale nie będzie można przypisać do niego
+              nowych.
+            </>
+          ) : (
+            ""
+          )
+        }
+        confirmLabel="Archiwizuj"
+        pendingLabel="Archiwizowanie..."
+        onConfirm={() => archiveMutation.mutate(archiveTarget!.id)}
+        isPending={archiveMutation.isPending}
+        contentClassName="max-w-md"
       />
 
       <ConfirmDialog

--- a/frontend/src/components/projects/ProjectList.tsx
+++ b/frontend/src/components/projects/ProjectList.tsx
@@ -227,7 +227,7 @@ export function ProjectList() {
         }
         confirmLabel="Archiwizuj"
         pendingLabel="Archiwizowanie..."
-        onConfirm={() => archiveMutation.mutate(archiveTarget!.id)}
+        onConfirm={() => archiveTarget && archiveMutation.mutate(archiveTarget.id)}
         isPending={archiveMutation.isPending}
         contentClassName="max-w-md"
       />

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -3,6 +3,7 @@ export interface Project {
   name: string;
   color: string;
   is_deleted: boolean;
+  is_archived: boolean;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary

- Adds `is_archived` field to the Project model (migration already existed: `b1e8c3d5f7a2`)
- New `POST /api/projects/{id}/archive` and `/unarchive` endpoints (require editor role)
- `GET /api/projects` gains `?status=active|archived|all` param (default: `active` — safe, backward-compatible)
- Project list gets status filter chips (All / Active / Archived), archive/unarchive action buttons, and an "Archived" badge
- Archived projects are hidden from the AssignmentModal project dropdown; when editing an existing assignment tied to an archived project, that project stays selectable
- Archiving does not affect existing assignments — they remain editable and deletable
- All existing projects default to `is_archived = false` via `server_default`

🤖 Generated with [Claude Code](https://claude.com/claude-code)