### PR TITLE
feat: show visible record count on lists and timeline

### DIFF
--- a/frontend/src/components/employees/EmployeeList.tsx
+++ b/frontend/src/components/employees/EmployeeList.tsx
@@ -12,6 +12,7 @@ import { SearchInput } from "@/components/ui/SearchInput";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { TeamFilterChips } from "@/components/common/TeamFilterChips";
+import { pluralizePl } from "@/lib/pluralizePl";
 import {
   createEmployee,
   deleteEmployee,
@@ -126,11 +127,11 @@ export function EmployeeList() {
         {!isLoading && (
           <span className="ml-auto text-sm text-muted-foreground tabular-nums">
             {employees.length}{" "}
-            {employees.length === 1
-              ? "pracownik"
-              : employees.length >= 2 && employees.length <= 4
-                ? "pracownicy"
-                : "pracowników"}
+            {pluralizePl(employees.length, [
+              "pracownik",
+              "pracownicy",
+              "pracowników",
+            ])}
           </span>
         )}
       </div>

--- a/frontend/src/components/employees/EmployeeList.tsx
+++ b/frontend/src/components/employees/EmployeeList.tsx
@@ -123,6 +123,16 @@ export function EmployeeList() {
           onToggleTeam={toggleTeam}
           onSelectAll={selectAllTeams}
         />
+        {!isLoading && (
+          <span className="ml-auto text-sm text-muted-foreground tabular-nums">
+            {employees.length}{" "}
+            {employees.length === 1
+              ? "pracownik"
+              : employees.length >= 2 && employees.length <= 4
+                ? "pracownicy"
+                : "pracowników"}
+          </span>
+        )}
       </div>
 
       <DataTable<Employee>

--- a/frontend/src/components/projects/ProjectList.tsx
+++ b/frontend/src/components/projects/ProjectList.tsx
@@ -149,6 +149,16 @@ export function ProjectList() {
             </button>
           ))}
         </div>
+        {!isLoading && (
+          <span className="ml-auto text-sm text-muted-foreground tabular-nums">
+            {projects.length}{" "}
+            {projects.length === 1
+              ? "projekt"
+              : projects.length >= 2 && projects.length <= 4
+                ? "projekty"
+                : "projektów"}
+          </span>
+        )}
       </div>
 
       <DataTable<Project>

--- a/frontend/src/components/projects/ProjectList.tsx
+++ b/frontend/src/components/projects/ProjectList.tsx
@@ -11,6 +11,7 @@ import { SearchInput } from "@/components/ui/SearchInput";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { cn } from "@/lib/utils";
+import { pluralizePl } from "@/lib/pluralizePl";
 import {
   archiveProject,
   createProject,
@@ -152,11 +153,7 @@ export function ProjectList() {
         {!isLoading && (
           <span className="ml-auto text-sm text-muted-foreground tabular-nums">
             {projects.length}{" "}
-            {projects.length === 1
-              ? "projekt"
-              : projects.length >= 2 && projects.length <= 4
-                ? "projekty"
-                : "projektów"}
+            {pluralizePl(projects.length, ["projekt", "projekty", "projektów"])}
           </span>
         )}
       </div>

--- a/frontend/src/components/timeline/Timeline.tsx
+++ b/frontend/src/components/timeline/Timeline.tsx
@@ -389,7 +389,7 @@ export function Timeline({ onNavigate }: TimelineProps = {}) {
           </div>
         </div>
 
-        <TimelineFilters />
+        <TimelineFilters count={isLoading ? undefined : displayedEmployees.length} />
       </div>
 
       {/* Body content */}

--- a/frontend/src/components/timeline/TimelineFilters.tsx
+++ b/frontend/src/components/timeline/TimelineFilters.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { SearchInput } from "@/components/ui/SearchInput";
 import { TeamFilterChips } from "@/components/common/TeamFilterChips";
 import { useTimelineStore } from "@/stores/timelineStore";
+import { pluralizePl } from "@/lib/pluralizePl";
 import type { ViewMode, UtilizationFilter } from "@/types/timeline";
 
 export function TimelineFilters({ count }: { count?: number }) {
@@ -155,11 +156,7 @@ export function TimelineFilters({ count }: { count?: number }) {
         {count !== undefined && (
           <span className="ml-auto text-sm text-muted-foreground tabular-nums">
             {count}{" "}
-            {count === 1
-              ? "pracownik"
-              : count >= 2 && count <= 4
-                ? "pracownicy"
-                : "pracowników"}
+            {pluralizePl(count, ["pracownik", "pracownicy", "pracowników"])}
           </span>
         )}
       </div>

--- a/frontend/src/components/timeline/TimelineFilters.tsx
+++ b/frontend/src/components/timeline/TimelineFilters.tsx
@@ -7,7 +7,7 @@ import { TeamFilterChips } from "@/components/common/TeamFilterChips";
 import { useTimelineStore } from "@/stores/timelineStore";
 import type { ViewMode, UtilizationFilter } from "@/types/timeline";
 
-export function TimelineFilters() {
+export function TimelineFilters({ count }: { count?: number }) {
   const {
     viewMode,
     setViewMode,
@@ -151,6 +151,17 @@ export function TimelineFilters() {
             <ChevronDown className="h-3 w-3" />
           )}
         </button>
+
+        {count !== undefined && (
+          <span className="ml-auto text-sm text-muted-foreground tabular-nums">
+            {count}{" "}
+            {count === 1
+              ? "pracownik"
+              : count >= 2 && count <= 4
+                ? "pracownicy"
+                : "pracowników"}
+          </span>
+        )}
       </div>
 
       {/* Utilization filter panel */}

--- a/frontend/src/lib/pluralizePl.ts
+++ b/frontend/src/lib/pluralizePl.ts
@@ -1,0 +1,17 @@
+/**
+ * Polish pluralization following CLDR plural rules.
+ * - one:  n === 1
+ * - few:  n % 10 in 2..4 and n % 100 not in 12..14 (e.g. 2, 23, 104)
+ * - many: everything else (e.g. 0, 5, 12, 25, 112)
+ */
+export function pluralizePl(
+  count: number,
+  forms: [one: string, few: string, many: string]
+): string {
+  const [one, few, many] = forms;
+  if (count === 1) return one;
+  const mod10 = count % 10;
+  const mod100 = count % 100;
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return few;
+  return many;
+}


### PR DESCRIPTION
## Summary

- Adds a visible record count indicator aligned to the right in the filter bar on employee list, project list, and timeline
- Count updates reactively with search, team filters, status filters, and utilization filters
- Hidden during loading state to avoid showing misleading `0`
- Uses Polish pluralization (`pracownik` / `pracownicy` / `pracowników`, `projekt` / `projekty` / `projektów`)

## Notes

- Branches off `feat/project-archiving` to stay conflict-free with the status filter already present in `ProjectList`
- `TimelineFilters` receives count as a prop from `Timeline` (where `displayedEmployees` is computed)