### PR TITLE
feat: Project Timeline view grouped by project

### DIFF
--- a/backend/app/api/project_timeline.py
+++ b/backend/app/api/project_timeline.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.dependencies import get_current_user, get_db
 from app.models.assignment import Assignment
+from app.models.employee import Employee
 from app.models.project import Project
 from app.models.user import User
 from app.services.assignment_service import calculate_daily_hours
@@ -61,12 +62,14 @@ async def get_project_timeline(
     project_ids = [p.id for p in projects]
     assignments_by_project: dict[int, list] = {pid: [] for pid in project_ids}
     if project_ids:
+        active_employee_ids = select(Employee.id).where(Employee.is_deleted == False)
         a_result = await db.execute(
             select(Assignment)
             .where(
                 Assignment.project_id.in_(project_ids),
                 Assignment.start_date <= end_date,
                 Assignment.end_date >= start_date,
+                Assignment.employee_id.in_(active_employee_ids),
             )
             .order_by(Assignment.start_date)
         )

--- a/backend/app/api/project_timeline.py
+++ b/backend/app/api/project_timeline.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import get_current_user, get_db
+from app.models.assignment import Assignment
+from app.models.project import Project
+from app.models.user import User
+from app.services.assignment_service import calculate_daily_hours
+from app.utils.polish_holidays import get_holiday_name, get_polish_holidays
+from app.utils.working_days import get_working_days_in_month
+
+router = APIRouter(tags=["project-timeline"])
+
+
+@router.get("/api/projects/timeline")
+async def get_project_timeline(
+    start_date: date = Query(...),
+    end_date: date = Query(...),
+    search: Optional[str] = Query(None),
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(get_current_user),
+):
+    """Return timeline data grouped by project."""
+    proj_query = select(Project).where(Project.is_deleted == False)
+    if search and search.strip():
+        proj_query = proj_query.where(Project.name.ilike(f"%{search.strip()}%"))
+    proj_query = proj_query.order_by(Project.name)
+
+    proj_result = await db.execute(proj_query)
+    projects = proj_result.scalars().all()
+
+    # Months in range
+    months = []
+    current = date(start_date.year, start_date.month, 1)
+    while current <= end_date:
+        months.append((current.year, current.month))
+        if current.month == 12:
+            current = date(current.year + 1, 1, 1)
+        else:
+            current = date(current.year, current.month + 1, 1)
+
+    # Holidays
+    holiday_dates = set()
+    for year in range(start_date.year, end_date.year + 1):
+        holiday_dates.update(get_polish_holidays(year))
+    holidays_in_range = sorted(d for d in holiday_dates if start_date <= d <= end_date)
+
+    # Working days per month
+    working_days_per_month = {
+        f"{y}-{m:02d}": get_working_days_in_month(y, m) for y, m in months
+    }
+
+    # Batch-fetch assignments for all projects in range
+    # Assignment.employee is selectin-loaded automatically
+    project_ids = [p.id for p in projects]
+    assignments_by_project: dict[int, list] = {pid: [] for pid in project_ids}
+    if project_ids:
+        a_result = await db.execute(
+            select(Assignment)
+            .where(
+                Assignment.project_id.in_(project_ids),
+                Assignment.start_date <= end_date,
+                Assignment.end_date >= start_date,
+            )
+            .order_by(Assignment.start_date)
+        )
+        for a in a_result.scalars().all():
+            assignments_by_project[a.project_id].append(a)
+
+    # Build project data
+    project_data = []
+    for proj in projects:
+        assignment_list = []
+        for a in assignments_by_project[proj.id]:
+            first_month_date = max(a.start_date, start_date)
+            daily = calculate_daily_hours(
+                a.allocation_type.value,
+                a.allocation_value,
+                first_month_date.year,
+                first_month_date.month,
+                start_date=a.start_date,
+                end_date=a.end_date,
+            )
+            emp = a.employee
+            assignment_list.append(
+                {
+                    "id": a.id,
+                    "employee_id": emp.id,
+                    "employee_name": f"{emp.last_name} {emp.first_name}",
+                    "employee_team": emp.team.value if emp.team else None,
+                    "start_date": a.start_date.isoformat(),
+                    "end_date": a.end_date.isoformat(),
+                    "allocation_type": a.allocation_type.value,
+                    "allocation_value": float(a.allocation_value),
+                    "note": a.note,
+                    "is_tentative": a.is_tentative,
+                    "daily_hours": float(round(daily, 2)),
+                }
+            )
+        project_data.append(
+            {
+                "id": proj.id,
+                "name": proj.name,
+                "color": proj.color,
+                "assignments": assignment_list,
+            }
+        )
+
+    return {
+        "projects": project_data,
+        "holidays": [
+            {"date": d.isoformat(), "name": get_holiday_name(d)}
+            for d in holidays_in_range
+        ],
+        "working_days_per_month": working_days_per_month,
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from app.api.auth import router as auth_router
 from app.api.assignments import router as assignments_router
 from app.api.calendar import router as calendar_router
 from app.api.employees import router as employees_router
+from app.api.project_timeline import router as project_timeline_router
 from app.api.projects import router as projects_router
 from app.api.settings import router as settings_router
 from app.api.users import router as users_router
@@ -56,6 +57,7 @@ app.include_router(employees_router)
 app.include_router(projects_router)
 app.include_router(assignments_router)
 app.include_router(calendar_router)
+app.include_router(project_timeline_router)
 app.include_router(settings_router)
 app.include_router(users_router)
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -47,6 +47,7 @@ On successful deletion: `{"deleted": true}` (200).
 
 ```
 GET    /api/projects                        # List projects (200)
+GET    /api/projects/timeline               # Timeline grouped by project (200, see below)
 POST   /api/projects                        # Create project, unique name (201)
 PATCH  /api/projects/{id}                   # Update project (200)
 DELETE /api/projects/{id}                   # Delete with cascade (200, see below)
@@ -212,6 +213,91 @@ GET /api/assignments/timeline?start_date=2026-01-01&end_date=2026-06-30&teams=Fr
 |---|---|---|
 | `last_synced_at` | datetime\|null | Last successful sync timestamp |
 | `is_configured` | bool | Whether Calamari integration is configured |
+
+## Project Timeline Endpoint
+
+Timeline data grouped by project (instead of by employee). Powers the Project Timeline view.
+
+### Request
+
+```
+GET /api/projects/timeline?start_date=2026-01-01&end_date=2026-06-30&search=Alpha
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `start_date` | date | yes | Range start (YYYY-MM-DD) |
+| `end_date` | date | yes | Range end (YYYY-MM-DD) |
+| `search` | string | no | Filter projects by name (case-insensitive substring) |
+
+### Response
+
+```json
+{
+  "projects": [
+    {
+      "id": 5,
+      "name": "Projekt Alpha",
+      "color": "#3B82F6",
+      "assignments": [
+        {
+          "id": 10,
+          "employee_id": 1,
+          "employee_name": "Kowalski Jan",
+          "employee_team": "Frontend",
+          "start_date": "2026-01-15",
+          "end_date": "2026-03-31",
+          "allocation_type": "percentage",
+          "allocation_value": 50,
+          "note": "Lead developer",
+          "is_tentative": false,
+          "daily_hours": 4.0
+        }
+      ]
+    }
+  ],
+  "holidays": [
+    {"date": "2026-01-01", "name": "Nowy Rok"},
+    {"date": "2026-01-06", "name": "Trzech Króli"}
+  ],
+  "working_days_per_month": {
+    "2026-01": 21,
+    "2026-02": 20,
+    "2026-03": 22
+  }
+}
+```
+
+### Response Fields
+
+**Project object:**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | int | Project ID |
+| `name` | string | Project name |
+| `color` | string | Hex color |
+| `assignments` | array | Assignments within requested date range (deleted employees excluded) |
+
+Non-deleted projects are always returned (sorted by name), even when they have no assignments in the range.
+
+**Assignment object (in project timeline):**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | int | Assignment ID |
+| `employee_id` | int | Employee ID |
+| `employee_name` | string | "Last First" format |
+| `employee_team` | string\|null | Team enum value |
+| `start_date` | date | Assignment start |
+| `end_date` | date | Assignment end |
+| `allocation_type` | enum | `percentage`, `monthly_hours`, or `total_hours` |
+| `allocation_value` | decimal | The raw allocation value |
+| `note` | string\|null | Optional note |
+| `is_tentative` | bool | Whether assignment is tentative |
+| `daily_hours` | float | Computed daily hours |
+
+`holidays` and `working_days_per_month` have the same shape as in the employee timeline endpoint. This endpoint does not return `utilization` or `vacation_sync_status`.
 
 ## HTTP Status Codes
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { ProjectList } from "@/components/projects/ProjectList";
 import { Timeline } from "@/components/timeline/Timeline";
 import { UserManagement } from "@/components/users/UserManagement";
 import { SettingsPage } from "@/components/settings/SettingsPage";
+import { ProjectTimeline } from "@/components/project-timeline/ProjectTimeline";
 
 function App() {
   const { isAuthenticated, isLoading, checkAuth, user } = useAuthStore();
@@ -65,6 +66,7 @@ function App() {
   return (
     <Layout currentPath={currentPath} onNavigate={navigate}>
       {currentPath === "/" && <Timeline onNavigate={navigate} />}
+      {currentPath === "/project-timeline" && <ProjectTimeline />}
       {currentPath === "/employees" && <EmployeeList />}
       {currentPath === "/projects" && <ProjectList />}
       {currentPath === "/users" && <UserManagement />}

--- a/frontend/src/api/projectTimeline.ts
+++ b/frontend/src/api/projectTimeline.ts
@@ -1,19 +1,12 @@
+import { apiFetch } from "./client";
 import type { ProjectTimelineData } from "@/types/project-timeline";
 
-export async function fetchProjectTimeline(
+export function fetchProjectTimeline(
   startDate: string,
   endDate: string,
   search?: string,
 ): Promise<ProjectTimelineData> {
   const params = new URLSearchParams({ start_date: startDate, end_date: endDate });
   if (search) params.set("search", search);
-
-  const res = await fetch(`/api/projects/timeline?${params}`, {
-    credentials: "include",
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({}));
-    throw new Error(err.detail ?? "Błąd pobierania project timeline");
-  }
-  return res.json();
+  return apiFetch<ProjectTimelineData>(`/api/projects/timeline?${params}`);
 }

--- a/frontend/src/api/projectTimeline.ts
+++ b/frontend/src/api/projectTimeline.ts
@@ -1,0 +1,19 @@
+import type { ProjectTimelineData } from "@/types/project-timeline";
+
+export async function fetchProjectTimeline(
+  startDate: string,
+  endDate: string,
+  search?: string,
+): Promise<ProjectTimelineData> {
+  const params = new URLSearchParams({ start_date: startDate, end_date: endDate });
+  if (search) params.set("search", search);
+
+  const res = await fetch(`/api/projects/timeline?${params}`, {
+    credentials: "include",
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail ?? "Błąd pobierania project timeline");
+  }
+  return res.json();
+}

--- a/frontend/src/components/assignments/AssignmentModal.tsx
+++ b/frontend/src/components/assignments/AssignmentModal.tsx
@@ -21,6 +21,7 @@ export function AssignmentModal({
   onClose,
   assignment,
   defaultEmployeeId,
+  defaultProjectId,
   defaultStartDate,
 }: AssignmentModalProps) {
   const queryClient = useQueryClient();
@@ -61,7 +62,7 @@ export function AssignmentModal({
       setIsTentative(assignment.is_tentative);
     } else {
       setEmployeeId(defaultEmployeeId ? String(defaultEmployeeId) : "");
-      setProjectId("");
+      setProjectId(defaultProjectId ? String(defaultProjectId) : "");
       setStartDate(defaultStartDate ?? "");
       setEndDate("");
       setAllocationType("percentage");
@@ -70,12 +71,13 @@ export function AssignmentModal({
       setIsTentative(false);
     }
     setShowDeleteConfirm(false);
-  }, [open, assignment, defaultEmployeeId, defaultStartDate]);
+  }, [open, assignment, defaultEmployeeId, defaultProjectId, defaultStartDate]);
 
   const createMutation = useMutation({
     mutationFn: createAssignment,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["timeline"] });
+      queryClient.invalidateQueries({ queryKey: ["project-timeline"] });
       toast.success("Assignment utworzony");
       onClose();
     },
@@ -87,6 +89,7 @@ export function AssignmentModal({
       updateAssignment(data[0], data[1]),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["timeline"] });
+      queryClient.invalidateQueries({ queryKey: ["project-timeline"] });
       toast.success("Assignment zaktualizowany");
       onClose();
     },
@@ -97,6 +100,7 @@ export function AssignmentModal({
     mutationFn: deleteAssignment,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["timeline"] });
+      queryClient.invalidateQueries({ queryKey: ["project-timeline"] });
       toast.success("Assignment usunięty");
       onClose();
     },

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Calendar, LogOut, Settings, UserCog, Users, FolderKanban } from "lucide-react";
+import { Calendar, GanttChart, LogOut, Settings, UserCog, Users, FolderKanban } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { useAuthStore } from "@/stores/authStore";
@@ -7,6 +7,7 @@ import type { SidebarProps } from "@/types/layout";
 
 const NAV_ITEMS = [
   { path: "/", label: "Timeline", icon: Calendar, viewerAllowed: true },
+  { path: "/project-timeline", label: "Project Timeline", icon: GanttChart, viewerAllowed: true },
   { path: "/employees", label: "Pracownicy", icon: Users, viewerAllowed: false },
   { path: "/projects", label: "Projekty", icon: FolderKanban, viewerAllowed: false },
 ] as const;

--- a/frontend/src/components/project-timeline/ProjectTimeline.tsx
+++ b/frontend/src/components/project-timeline/ProjectTimeline.tsx
@@ -1,0 +1,495 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  DndContext,
+  DragOverlay,
+  type DragEndEvent,
+  type DragStartEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { addDays, parseISO, format } from "date-fns";
+import { pl } from "date-fns/locale";
+import { Copy, Plus, Scissors } from "lucide-react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { createPortal } from "react-dom";
+import { Button } from "@/components/ui/button";
+import { useProjectTimeline } from "@/hooks/useProjectTimeline";
+import { useProjectTimelineStore } from "@/stores/projectTimelineStore";
+import { useAuthStore } from "@/stores/authStore";
+import { ProjectTimelineFilters } from "./ProjectTimelineFilters";
+import { ProjectTimelineRow } from "./ProjectTimelineRow";
+import { TimelineHeader, MONTH_WIDTH, DAY_WIDTH } from "@/components/timeline/TimelineHeader";
+import { TimelineBarDragPreview } from "@/components/timeline/TimelineBarDragPreview";
+import { AssignmentModal } from "@/components/assignments/AssignmentModal";
+import {
+  updateAssignment,
+  splitAssignment,
+  duplicateAssignment,
+} from "@/api/assignments";
+import type { TimelineAssignment } from "@/types/assignment";
+import type { ProjectTimelineAssignment, ProjectTimelineProject } from "@/types/project-timeline";
+import { TIMELINE_LEFT_PANEL_WIDTH } from "@/lib/constants";
+import { Search, FolderOpen } from "lucide-react";
+
+function adaptForModal(
+  assignment: ProjectTimelineAssignment,
+  project: ProjectTimelineProject,
+): TimelineAssignment {
+  return {
+    id: assignment.id,
+    project_id: project.id,
+    project_name: project.name,
+    project_color: project.color,
+    start_date: assignment.start_date,
+    end_date: assignment.end_date,
+    allocation_type: assignment.allocation_type,
+    allocation_value: assignment.allocation_value,
+    note: assignment.note,
+    is_tentative: assignment.is_tentative,
+    daily_hours: assignment.daily_hours,
+  };
+}
+
+export function ProjectTimeline() {
+  const queryClient = useQueryClient();
+  const { data, isLoading, months, weeks, allDays, viewMode } = useProjectTimeline();
+  const searchQuery = useProjectTimelineStore((s) => s.searchQuery);
+  const currentUser = useAuthStore((s) => s.user);
+  const isViewer = currentUser?.role === "viewer";
+
+  const holidayMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    if (data?.holidays) {
+      for (const h of data.holidays) map[h.date] = h.name;
+    }
+    return map;
+  }, [data?.holidays]);
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingAssignment, setEditingAssignment] = useState<TimelineAssignment | null>(null);
+  const [editingEmployeeId, setEditingEmployeeId] = useState<number | null>(null);
+  const [defaultProjectId, setDefaultProjectId] = useState<number | null>(null);
+  const [defaultStartDate, setDefaultStartDate] = useState<string | null>(null);
+
+  const [dragPreview, setDragPreview] = useState<{
+    assignment: TimelineAssignment;
+    barWidth: number;
+    showDailyHours: boolean;
+  } | null>(null);
+
+  const [contextMenu, setContextMenu] = useState<{
+    x: number;
+    y: number;
+    splitDate: string;
+    splitDateLabel: string;
+    splitDateIsValid: boolean;
+    assignmentId: number;
+  } | null>(null);
+  const contextMenuRef = useRef<HTMLDivElement>(null);
+  const toolbarRef = useRef<HTMLDivElement>(null);
+  const [timelineGridMaxHeight, setTimelineGridMaxHeight] = useState<string | undefined>(
+    "min(80dvh, calc(100dvh - 12rem))",
+  );
+
+  useLayoutEffect(() => {
+    const toolbar = toolbarRef.current;
+    if (!toolbar) return;
+    const update = () => {
+      const h = Math.round(toolbar.getBoundingClientRect().height);
+      setTimelineGridMaxHeight(`calc(100dvh - ${h}px - 2.5rem)`);
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(toolbar);
+    window.addEventListener("resize", update);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("resize", update);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!contextMenu) return;
+    const handleMouseDown = (e: MouseEvent) => {
+      if (contextMenuRef.current && !contextMenuRef.current.contains(e.target as Node)) {
+        setContextMenu(null);
+      }
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setContextMenu(null);
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [contextMenu]);
+
+  const totalWidth =
+    viewMode === "weekly" ? allDays.length * DAY_WIDTH : months.length * MONTH_WIDTH;
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  );
+
+  const splitMutation = useMutation({
+    mutationFn: ({ id, date }: { id: number; date: string }) => splitAssignment(id, date),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["project-timeline"] });
+      queryClient.invalidateQueries({ queryKey: ["timeline"] });
+      toast.success("Assignment podzielony");
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const duplicateMutation = useMutation({
+    mutationFn: (id: number) => duplicateAssignment(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["project-timeline"] });
+      queryClient.invalidateQueries({ queryKey: ["timeline"] });
+      toast.success("Assignment zduplikowany");
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const patchMutation = useMutation({
+    mutationFn: ({ id, data: patchData }: { id: number; data: Record<string, unknown> }) =>
+      updateAssignment(id, patchData),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["project-timeline"] });
+      queryClient.invalidateQueries({ queryKey: ["timeline"] });
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const handleBarContextMenu = useCallback(
+    (
+      assignmentId: number,
+      x: number,
+      y: number,
+      splitDate: string,
+      splitDateIsValid: boolean,
+    ) => {
+      setContextMenu({
+        x,
+        y,
+        splitDate,
+        splitDateLabel: format(parseISO(splitDate), "d.MM.yyyy", { locale: pl }),
+        splitDateIsValid,
+        assignmentId,
+      });
+      setModalOpen(false);
+      setEditingAssignment(null);
+    },
+    [],
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    const d = event.active.data.current as
+      | { assignment: TimelineAssignment; barWidth: number; showDailyHours: boolean }
+      | undefined;
+    if (d?.assignment != null) {
+      setDragPreview({ assignment: d.assignment, barWidth: d.barWidth, showDailyHours: d.showDailyHours });
+    }
+  }, []);
+
+  // D&D — move assignment to a different project
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over) return;
+      const dragData = active.data.current as { assignment: TimelineAssignment; employeeId: number };
+      const dropData = over.data.current as { projectId: number };
+      if (!dragData || !dropData) return;
+      // employeeId in drag data is actually the source projectId (passed by ProjectTimelineRow)
+      if (dragData.employeeId === dropData.projectId) return;
+      patchMutation.mutate(
+        { id: dragData.assignment.id, data: { project_id: dropData.projectId } },
+        {
+          onSuccess: () => {
+            const targetName =
+              data?.projects.find((p) => p.id === dropData.projectId)?.name ?? "innego projektu";
+            toast.success(`Assignment przeniesiony na ${targetName}`);
+          },
+        },
+      );
+    },
+    [patchMutation, data],
+  );
+
+  const handleDragEndWithPreview = useCallback(
+    (event: DragEndEvent) => {
+      setDragPreview(null);
+      handleDragEnd(event);
+    },
+    [handleDragEnd],
+  );
+
+  const handleResizeEnd = useCallback(
+    (assignmentId: number, edge: "left" | "right", deltaPx: number) => {
+      if (!data) return;
+      let assignment: ProjectTimelineAssignment | undefined;
+      for (const proj of data.projects) {
+        assignment = proj.assignments.find((a) => a.id === assignmentId);
+        if (assignment) break;
+      }
+      if (!assignment) return;
+
+      let pxPerDay: number;
+      if (viewMode === "weekly") {
+        pxPerDay = DAY_WIDTH;
+      } else {
+        const totalPx = months.length * MONTH_WIDTH;
+        const firstMonth = months[0];
+        const lastMonth = months[months.length - 1];
+        const firstDate = new Date(firstMonth.year, firstMonth.month - 1, 1);
+        const lastDate = new Date(lastMonth.year, lastMonth.month, 0);
+        const totalDays =
+          Math.round((lastDate.getTime() - firstDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+        pxPerDay = totalPx / totalDays;
+      }
+
+      const daysDelta = Math.round(deltaPx / pxPerDay);
+      if (daysDelta === 0) return;
+
+      const patchData: Record<string, string> = {};
+      if (edge === "left") {
+        patchData.start_date = format(addDays(parseISO(assignment.start_date), daysDelta), "yyyy-MM-dd");
+      } else {
+        patchData.end_date = format(addDays(parseISO(assignment.end_date), daysDelta), "yyyy-MM-dd");
+      }
+
+      patchMutation.mutate(
+        { id: assignmentId, data: patchData },
+        { onSuccess: () => toast.success("Daty zaktualizowane") },
+      );
+    },
+    [data, months, viewMode, patchMutation],
+  );
+
+  const handleAssignmentClick = (
+    assignment: ProjectTimelineAssignment,
+    project: ProjectTimelineProject,
+  ) => {
+    setEditingAssignment(adaptForModal(assignment, project));
+    setEditingEmployeeId(assignment.employee_id);
+    setDefaultProjectId(null);
+    setDefaultStartDate(null);
+    setModalOpen(true);
+  };
+
+  const handleEmptyClick = (projectId: number, dateKey: string) => {
+    setEditingAssignment(null);
+    setEditingEmployeeId(null);
+    setDefaultProjectId(projectId);
+    setDefaultStartDate(dateKey.length === 10 ? dateKey : `${dateKey}-01`);
+    setModalOpen(true);
+  };
+
+  const handleNewAssignment = () => {
+    setEditingAssignment(null);
+    setEditingEmployeeId(null);
+    setDefaultProjectId(null);
+    setDefaultStartDate(null);
+    setModalOpen(true);
+  };
+
+  const displayedProjects = data?.projects ?? [];
+  const trimmedSearch = searchQuery.trim();
+
+  return (
+    <div>
+      <div ref={toolbarRef} className="sticky top-0 z-30 bg-background px-6 pt-6">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-2xl font-bold">Project Timeline</h2>
+          {!isViewer && (
+            <Button onClick={handleNewAssignment}>
+              <Plus className="mr-2 h-4 w-4" />
+              Dodaj assignment
+            </Button>
+          )}
+        </div>
+        <ProjectTimelineFilters count={isLoading ? undefined : displayedProjects.length} />
+      </div>
+
+      {isLoading ? (
+        <div className="mx-6 rounded-md border">
+          <div className="flex border-b">
+            <div className="shrink-0 border-r p-3" style={{ width: TIMELINE_LEFT_PANEL_WIDTH }}>
+              <div className="h-4 w-20 animate-pulse rounded bg-muted" />
+            </div>
+            <div className="flex flex-1">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className="w-[200px] shrink-0 border-r p-3">
+                  <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+                  <div className="mt-1 h-3 w-16 animate-pulse rounded bg-muted" />
+                </div>
+              ))}
+            </div>
+          </div>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="flex border-b">
+              <div className="shrink-0 border-r p-3" style={{ width: TIMELINE_LEFT_PANEL_WIDTH }}>
+                <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+              </div>
+              <div className="flex-1 p-3">
+                <div
+                  className="h-7 animate-pulse rounded bg-muted"
+                  style={{ width: `${120 + i * 40}px` }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : !data || displayedProjects.length === 0 ? (
+        <div className="mx-6 flex min-h-[280px] flex-col items-center justify-center rounded-lg border border-dashed bg-muted/30 px-6 py-12 text-center">
+          <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted" aria-hidden>
+            {trimmedSearch ? (
+              <Search className="h-6 w-6 text-muted-foreground" />
+            ) : (
+              <FolderOpen className="h-6 w-6 text-muted-foreground" />
+            )}
+          </div>
+          <h3 className="text-lg font-semibold tracking-tight text-foreground">
+            {trimmedSearch ? `Brak wyników dla „${trimmedSearch}"` : "Brak projektów"}
+          </h3>
+          <p className="mt-2 max-w-md text-sm text-muted-foreground">
+            {trimmedSearch
+              ? "Spróbuj innej frazy albo wyczyść wyszukiwanie."
+              : "Dodaj projekty i assignmenty, aby zobaczyć plan projektów w tym widoku."}
+          </p>
+        </div>
+      ) : (
+        <DndContext
+          sensors={sensors}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEndWithPreview}
+          onDragCancel={() => setDragPreview(null)}
+        >
+          <div className="mx-6 min-w-0 rounded-md border bg-background shadow-[0_2px_4px_rgba(0,0,0,0.1)]">
+            <div
+              className="overflow-auto overscroll-contain"
+              style={{ maxHeight: timelineGridMaxHeight }}
+            >
+              <div style={{ minWidth: TIMELINE_LEFT_PANEL_WIDTH + totalWidth }}>
+                {/* Sticky header row */}
+                <div
+                  className="sticky top-0 z-20 flex border-b bg-muted shadow-sm"
+                  style={{ minWidth: TIMELINE_LEFT_PANEL_WIDTH + totalWidth }}
+                >
+                  <div
+                    className="sticky left-0 z-30 flex shrink-0 items-center border-r bg-muted px-3 py-2"
+                    style={{ width: TIMELINE_LEFT_PANEL_WIDTH }}
+                  >
+                    <span className="text-sm font-medium">Projekt</span>
+                  </div>
+                  <div className="flex shrink-0" style={{ minWidth: totalWidth }}>
+                    <TimelineHeader
+                      viewMode={viewMode}
+                      months={months}
+                      workingDaysPerMonth={data.working_days_per_month}
+                      weeks={weeks}
+                      allDays={allDays}
+                      holidayMap={holidayMap}
+                    />
+                  </div>
+                </div>
+
+                {/* Project rows */}
+                {displayedProjects.map((project, idx) => (
+                  <ProjectTimelineRow
+                    key={project.id}
+                    project={project}
+                    months={months}
+                    allDays={allDays}
+                    viewMode={viewMode}
+                    holidayMap={holidayMap}
+                    onAssignmentClick={(a) => handleAssignmentClick(a, project)}
+                    onEmptyClick={handleEmptyClick}
+                    onResizeEnd={handleResizeEnd}
+                    onBarContextMenu={handleBarContextMenu}
+                    readOnly={isViewer}
+                    isOdd={idx % 2 === 1}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <DragOverlay dropAnimation={null}>
+            {dragPreview ? (
+              <TimelineBarDragPreview
+                assignment={dragPreview.assignment}
+                width={dragPreview.barWidth}
+                showDailyHours={dragPreview.showDailyHours}
+              />
+            ) : null}
+          </DragOverlay>
+        </DndContext>
+      )}
+
+      <div className="pb-6" />
+
+      {/* Context menu for split / duplicate */}
+      {contextMenu &&
+        createPortal(
+          <div
+            ref={contextMenuRef}
+            className="fixed z-[9999] min-w-44 overflow-hidden rounded-md border bg-popover py-1 shadow-md"
+            style={{
+              left: Math.min(contextMenu.x, window.innerWidth - 200),
+              top: Math.min(contextMenu.y, window.innerHeight - 100),
+            }}
+          >
+            <button
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent disabled:cursor-not-allowed disabled:opacity-40"
+              disabled={!contextMenu.splitDateIsValid}
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={() => {
+                splitMutation.mutate({ id: contextMenu.assignmentId, date: contextMenu.splitDate });
+                setContextMenu(null);
+              }}
+            >
+              <Scissors size={13} className="shrink-0" />
+              <span>Podziel: {contextMenu.splitDateLabel}</span>
+            </button>
+            <button
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent"
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={() => {
+                duplicateMutation.mutate(contextMenu.assignmentId);
+                setContextMenu(null);
+              }}
+            >
+              <Copy size={13} className="shrink-0" />
+              <span>Duplikuj</span>
+            </button>
+          </div>,
+          document.body,
+        )}
+
+      <AssignmentModal
+        open={modalOpen}
+        onClose={() => {
+          setModalOpen(false);
+          setEditingAssignment(null);
+          setEditingEmployeeId(null);
+        }}
+        assignment={editingAssignment}
+        defaultEmployeeId={editingEmployeeId}
+        defaultProjectId={defaultProjectId}
+        defaultStartDate={defaultStartDate}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/project-timeline/ProjectTimelineFilters.tsx
+++ b/frontend/src/components/project-timeline/ProjectTimelineFilters.tsx
@@ -1,0 +1,74 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { SearchInput } from "@/components/ui/SearchInput";
+import { useProjectTimelineStore } from "@/stores/projectTimelineStore";
+import type { ViewMode } from "@/types/timeline";
+
+export function ProjectTimelineFilters({ count }: { count?: number }) {
+  const {
+    viewMode,
+    setViewMode,
+    searchQuery,
+    setSearchQuery,
+    scrollBack,
+    scrollForward,
+    goToToday,
+  } = useProjectTimelineStore();
+
+  return (
+    <div className="mb-4 space-y-2">
+      {/* Row 1: View mode + Navigation */}
+      <div className="flex items-center gap-3">
+        <div className="flex rounded-md border">
+          {(["monthly", "weekly"] as ViewMode[]).map((mode) => (
+            <button
+              key={mode}
+              onClick={() => setViewMode(mode)}
+              className={`px-3 py-1.5 text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 ${
+                viewMode === mode
+                  ? "bg-primary text-primary-foreground"
+                  : "hover:bg-muted"
+              } ${mode === "monthly" ? "rounded-l-md" : "rounded-r-md"}`}
+              aria-pressed={viewMode === mode}
+            >
+              {mode === "monthly" ? "Miesięczny" : "Tygodniowy"}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-1">
+          <Button variant="outline" size="sm" onClick={scrollBack}>
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Button variant="outline" size="sm" onClick={goToToday}>
+            Dzisiaj
+          </Button>
+          <Button variant="outline" size="sm" onClick={scrollForward}>
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Row 2: Search + count */}
+      <div className="flex items-center gap-3">
+        <SearchInput
+          className="w-56"
+          placeholder="Szukaj projektu..."
+          value={searchQuery}
+          onChange={setSearchQuery}
+        />
+
+        {count !== undefined && (
+          <span className="ml-auto text-sm text-muted-foreground tabular-nums">
+            {count}{" "}
+            {count === 1
+              ? "projekt"
+              : count >= 2 && count <= 4
+                ? "projekty"
+                : "projektów"}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/project-timeline/ProjectTimelineRow.tsx
+++ b/frontend/src/components/project-timeline/ProjectTimelineRow.tsx
@@ -1,0 +1,322 @@
+import { useDroppable } from "@dnd-kit/core";
+import {
+  startOfMonth,
+  endOfMonth,
+  differenceInCalendarDays,
+  parseISO,
+  max as dateMax,
+  min as dateMin,
+  addDays,
+  format,
+} from "date-fns";
+import type { ProjectTimelineAssignment, ProjectTimelineProject } from "@/types/project-timeline";
+import type { TimelineAssignment } from "@/types/assignment";
+import type { MonthDef, DateRange, DayInfo } from "@/types/timeline";
+import { TimelineBar } from "@/components/timeline/TimelineBar";
+import { MONTH_WIDTH, DAY_WIDTH } from "@/components/timeline/TimelineHeader";
+import { TIMELINE_LEFT_PANEL_WIDTH } from "@/lib/constants";
+
+function getMonthlyPixelPosition(date: Date, months: MonthDef[]): number {
+  const monthIndex = months.findIndex(
+    (m) => m.year === date.getFullYear() && m.month === date.getMonth() + 1,
+  );
+  if (monthIndex < 0) {
+    if (date < startOfMonth(new Date(months[0].year, months[0].month - 1, 1)))
+      return 0;
+    return months.length * MONTH_WIDTH;
+  }
+  const monthStart = startOfMonth(date);
+  const monthEnd = endOfMonth(date);
+  const daysInMonth = differenceInCalendarDays(monthEnd, monthStart) + 1;
+  const dayOffset = differenceInCalendarDays(date, monthStart);
+  return monthIndex * MONTH_WIDTH + (dayOffset / daysInMonth) * MONTH_WIDTH;
+}
+
+function getDateFromMonthlyPixelPosition(timelineX: number, months: MonthDef[]): Date {
+  if (months.length === 0) return new Date();
+  const maxX = months.length * MONTH_WIDTH;
+  const clampedX = Math.max(0, Math.min(timelineX, maxX - Number.EPSILON));
+  const monthIndex = Math.min(Math.floor(clampedX / MONTH_WIDTH), months.length - 1);
+  const m = months[monthIndex];
+  const monthStart = startOfMonth(new Date(m.year, m.month - 1, 1));
+  const monthEnd = endOfMonth(monthStart);
+  const daysInMonth = differenceInCalendarDays(monthEnd, monthStart) + 1;
+  const relWithinMonth = clampedX - monthIndex * MONTH_WIDTH;
+  const dayOffset = Math.min(
+    Math.floor((relWithinMonth / MONTH_WIDTH) * daysInMonth),
+    daysInMonth - 1,
+  );
+  return addDays(monthStart, dayOffset);
+}
+
+function computeBarPositionMonthly(
+  item: DateRange,
+  months: MonthDef[],
+): { left: number; width: number; visibleStart: Date } | null {
+  if (months.length === 0) return null;
+  const aStart = parseISO(item.start_date);
+  const aEnd = parseISO(item.end_date);
+  const firstMonthStart = startOfMonth(new Date(months[0].year, months[0].month - 1, 1));
+  const lastMonth = months[months.length - 1];
+  const lastMonthEnd = endOfMonth(new Date(lastMonth.year, lastMonth.month - 1, 1));
+  if (aEnd < firstMonthStart || aStart > lastMonthEnd) return null;
+  const visibleStart = dateMax([aStart, firstMonthStart]);
+  const visibleEnd = dateMin([aEnd, lastMonthEnd]);
+  const left = getMonthlyPixelPosition(visibleStart, months);
+  const right = getMonthlyPixelPosition(addDays(visibleEnd, 1), months);
+  return { left, width: right - left, visibleStart };
+}
+
+function computeBarPositionWeekly(
+  item: DateRange,
+  allDays: DayInfo[],
+): { left: number; width: number; visibleStart: Date } | null {
+  if (allDays.length === 0) return null;
+  const aStart = parseISO(item.start_date);
+  const aEnd = parseISO(item.end_date);
+  const firstDay = allDays[0].date;
+  const lastDay = allDays[allDays.length - 1].date;
+  if (aEnd < firstDay || aStart > lastDay) return null;
+  const visibleStart = dateMax([aStart, firstDay]);
+  const visibleEnd = dateMin([aEnd, lastDay]);
+  const leftDays = differenceInCalendarDays(visibleStart, firstDay);
+  const spanDays = differenceInCalendarDays(visibleEnd, visibleStart) + 1;
+  return { left: leftDays * DAY_WIDTH, width: spanDays * DAY_WIDTH, visibleStart };
+}
+
+function getResizeHandleVisibility(
+  assignment: { start_date: string; end_date: string },
+  isWeekly: boolean,
+  months: MonthDef[],
+  allDays: DayInfo[],
+): { showResizeLeft: boolean; showResizeRight: boolean } {
+  if (isWeekly) {
+    if (allDays.length === 0) return { showResizeLeft: false, showResizeRight: false };
+    return {
+      showResizeLeft: assignment.start_date >= allDays[0].key,
+      showResizeRight: assignment.end_date <= allDays[allDays.length - 1].key,
+    };
+  }
+  if (months.length === 0) return { showResizeLeft: false, showResizeRight: false };
+  const firstKey = format(
+    startOfMonth(new Date(months[0].year, months[0].month - 1, 1)),
+    "yyyy-MM-dd",
+  );
+  const lastM = months[months.length - 1];
+  const lastKey = format(endOfMonth(new Date(lastM.year, lastM.month - 1, 1)), "yyyy-MM-dd");
+  return {
+    showResizeLeft: assignment.start_date >= firstKey,
+    showResizeRight: assignment.end_date <= lastKey,
+  };
+}
+
+function assignRow(
+  pos: { left: number; width: number },
+  occupiedRows: { left: number; right: number; row: number }[],
+): number {
+  let row = 0;
+  const right = pos.left + pos.width;
+  while (occupiedRows.some((o) => o.row === row && pos.left < o.right && right > o.left)) {
+    row++;
+  }
+  occupiedRows.push({ left: pos.left, right, row });
+  return row;
+}
+
+interface ProjectTimelineRowProps {
+  project: ProjectTimelineProject;
+  months: MonthDef[];
+  allDays: DayInfo[];
+  viewMode: "monthly" | "weekly";
+  holidayMap: Record<string, string>;
+  onAssignmentClick: (assignment: ProjectTimelineAssignment) => void;
+  onEmptyClick: (projectId: number, dateKey: string) => void;
+  onResizeEnd: (assignmentId: number, edge: "left" | "right", deltaPx: number) => void;
+  onBarContextMenu: (
+    assignmentId: number,
+    x: number,
+    y: number,
+    splitDate: string,
+    splitDateIsValid: boolean,
+  ) => void;
+  isOdd: boolean;
+  readOnly?: boolean;
+}
+
+export function ProjectTimelineRow({
+  project,
+  months,
+  allDays,
+  viewMode,
+  holidayMap,
+  onAssignmentClick,
+  onEmptyClick,
+  onResizeEnd,
+  onBarContextMenu,
+  isOdd,
+  readOnly = false,
+}: ProjectTimelineRowProps) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `project-${project.id}`,
+    data: { projectId: project.id },
+  });
+
+  const isWeekly = viewMode === "weekly";
+
+  let pxPerDay = 1;
+  if (isWeekly) {
+    pxPerDay = DAY_WIDTH;
+  } else if (months.length > 0) {
+    const firstMonthStart = startOfMonth(new Date(months[0].year, months[0].month - 1, 1));
+    const lastMonth = months[months.length - 1];
+    const lastMonthEnd = endOfMonth(new Date(lastMonth.year, lastMonth.month - 1, 1));
+    const totalDays = differenceInCalendarDays(lastMonthEnd, firstMonthStart) + 1;
+    const totalWidth = months.length * MONTH_WIDTH;
+    pxPerDay = totalDays > 0 ? totalWidth / totalDays : 1;
+  }
+
+  const occupiedRows: { left: number; right: number; row: number }[] = [];
+
+  const computePos = (item: DateRange) =>
+    isWeekly
+      ? computeBarPositionWeekly(item, allDays)
+      : computeBarPositionMonthly(item, months);
+
+  // Adapt ProjectTimelineAssignment → TimelineAssignment for TimelineBar reuse
+  const bars = project.assignments.flatMap((assignment) => {
+    const pos = computePos(assignment);
+    if (!pos) return [];
+    const adapted: TimelineAssignment = {
+      id: assignment.id,
+      project_id: project.id,
+      project_name: assignment.employee_name,
+      project_color: project.color,
+      start_date: assignment.start_date,
+      end_date: assignment.end_date,
+      allocation_type: assignment.allocation_type,
+      allocation_value: assignment.allocation_value,
+      note: assignment.note,
+      is_tentative: assignment.is_tentative,
+      daily_hours: assignment.daily_hours,
+    };
+    return [{ original: assignment, adapted, ...pos, row: assignRow(pos, occupiedRows) }];
+  });
+
+  const maxRows = bars.length > 0 ? Math.max(...bars.map((b) => b.row)) + 1 : 1;
+  const barRowHeight = 32;
+  const rowHeight = Math.max(38, maxRows * barRowHeight + 6);
+
+  const totalWidth = isWeekly ? allDays.length * DAY_WIDTH : months.length * MONTH_WIDTH;
+
+  const separatorColumns = isWeekly
+    ? allDays.map((day, i) => ({
+        key: day.key,
+        left: i * DAY_WIDTH,
+        width: DAY_WIDTH,
+        clickKey: day.key,
+        extraClassName: day.isWeekend || !!holidayMap[day.key] ? "bg-muted/40" : "",
+        title: holidayMap[day.key],
+      }))
+    : months.map((m, i) => ({
+        key: m.key,
+        left: i * MONTH_WIDTH,
+        width: MONTH_WIDTH,
+        clickKey: m.key,
+        extraClassName: "",
+        title: undefined as string | undefined,
+      }));
+
+  return (
+    <div
+      className={`flex border-b ${isOdd ? "bg-muted/20" : ""} ${
+        isOver ? "ring-2 ring-inset ring-primary/50" : ""
+      }`}
+      style={{ minWidth: TIMELINE_LEFT_PANEL_WIDTH + totalWidth }}
+    >
+      {/* Sticky left panel */}
+      <div
+        className="sticky left-0 z-10 flex shrink-0 items-center gap-2 border-r bg-background px-3 py-2"
+        style={{ width: TIMELINE_LEFT_PANEL_WIDTH, minHeight: rowHeight }}
+      >
+        <span
+          className="inline-block h-3 w-3 shrink-0 rounded-sm"
+          style={{ backgroundColor: project.color }}
+        />
+        <span className="min-w-0 flex-1 truncate text-sm font-medium">{project.name}</span>
+      </div>
+
+      {/* Timeline area */}
+      <div
+        ref={setNodeRef}
+        className="relative flex-1"
+        style={{ minWidth: totalWidth, minHeight: rowHeight }}
+      >
+        {/* Separator columns */}
+        {separatorColumns.map((col) => (
+          <div
+            key={col.key}
+            role={readOnly ? undefined : "button"}
+            tabIndex={readOnly ? undefined : 0}
+            aria-label={readOnly ? undefined : `Dodaj assignment ${col.key}`}
+            className={`absolute border-r border-dashed border-muted-foreground/20 ${
+              readOnly ? "" : "cursor-pointer"
+            } ${col.extraClassName}`}
+            style={{ left: col.left, width: col.width, top: 0, height: "100%" }}
+            title={col.title}
+            onClick={readOnly ? undefined : () => onEmptyClick(project.id, col.clickKey)}
+            onKeyDown={
+              readOnly
+                ? undefined
+                : (e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      onEmptyClick(project.id, col.clickKey);
+                    }
+                  }
+            }
+          />
+        ))}
+
+        {/* Assignment bars */}
+        {bars.map((bar) => {
+          const resizeVis = getResizeHandleVisibility(bar.adapted, isWeekly, months, allDays);
+          return (
+            <div
+              key={bar.adapted.id}
+              className="absolute"
+              style={{ top: bar.row * barRowHeight + 2 }}
+            >
+              <TimelineBar
+                assignment={bar.adapted}
+                employeeId={project.id}
+                left={bar.left}
+                width={bar.width}
+                barStartDate={format(bar.visibleStart, "yyyy-MM-dd")}
+                onClick={() => onAssignmentClick(bar.original)}
+                onResizeEnd={onResizeEnd}
+                onBarContextMenu={(x, y, splitDate, splitDateIsValid) =>
+                  onBarContextMenu(bar.adapted.id, x, y, splitDate, splitDateIsValid)
+                }
+                splitDateFromRelX={
+                  isWeekly
+                    ? undefined
+                    : (relX) =>
+                        format(
+                          getDateFromMonthlyPixelPosition(bar.left + relX, months),
+                          "yyyy-MM-dd",
+                        )
+                }
+                pxPerDay={pxPerDay}
+                showDailyHours={isWeekly}
+                showResizeDateTooltip={!isWeekly}
+                readOnly={readOnly}
+                showResizeLeft={resizeVis.showResizeLeft}
+                showResizeRight={resizeVis.showResizeRight}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/project-timeline/ProjectTimelineRow.tsx
+++ b/frontend/src/components/project-timeline/ProjectTimelineRow.tsx
@@ -1,127 +1,18 @@
 import { useDroppable } from "@dnd-kit/core";
-import {
-  startOfMonth,
-  endOfMonth,
-  differenceInCalendarDays,
-  parseISO,
-  max as dateMax,
-  min as dateMin,
-  addDays,
-  format,
-} from "date-fns";
+import { startOfMonth, endOfMonth, differenceInCalendarDays, format } from "date-fns";
 import type { ProjectTimelineAssignment, ProjectTimelineProject } from "@/types/project-timeline";
 import type { TimelineAssignment } from "@/types/assignment";
 import type { MonthDef, DateRange, DayInfo } from "@/types/timeline";
 import { TimelineBar } from "@/components/timeline/TimelineBar";
 import { MONTH_WIDTH, DAY_WIDTH } from "@/components/timeline/TimelineHeader";
 import { TIMELINE_LEFT_PANEL_WIDTH } from "@/lib/constants";
-
-function getMonthlyPixelPosition(date: Date, months: MonthDef[]): number {
-  const monthIndex = months.findIndex(
-    (m) => m.year === date.getFullYear() && m.month === date.getMonth() + 1,
-  );
-  if (monthIndex < 0) {
-    if (date < startOfMonth(new Date(months[0].year, months[0].month - 1, 1)))
-      return 0;
-    return months.length * MONTH_WIDTH;
-  }
-  const monthStart = startOfMonth(date);
-  const monthEnd = endOfMonth(date);
-  const daysInMonth = differenceInCalendarDays(monthEnd, monthStart) + 1;
-  const dayOffset = differenceInCalendarDays(date, monthStart);
-  return monthIndex * MONTH_WIDTH + (dayOffset / daysInMonth) * MONTH_WIDTH;
-}
-
-function getDateFromMonthlyPixelPosition(timelineX: number, months: MonthDef[]): Date {
-  if (months.length === 0) return new Date();
-  const maxX = months.length * MONTH_WIDTH;
-  const clampedX = Math.max(0, Math.min(timelineX, maxX - Number.EPSILON));
-  const monthIndex = Math.min(Math.floor(clampedX / MONTH_WIDTH), months.length - 1);
-  const m = months[monthIndex];
-  const monthStart = startOfMonth(new Date(m.year, m.month - 1, 1));
-  const monthEnd = endOfMonth(monthStart);
-  const daysInMonth = differenceInCalendarDays(monthEnd, monthStart) + 1;
-  const relWithinMonth = clampedX - monthIndex * MONTH_WIDTH;
-  const dayOffset = Math.min(
-    Math.floor((relWithinMonth / MONTH_WIDTH) * daysInMonth),
-    daysInMonth - 1,
-  );
-  return addDays(monthStart, dayOffset);
-}
-
-function computeBarPositionMonthly(
-  item: DateRange,
-  months: MonthDef[],
-): { left: number; width: number; visibleStart: Date } | null {
-  if (months.length === 0) return null;
-  const aStart = parseISO(item.start_date);
-  const aEnd = parseISO(item.end_date);
-  const firstMonthStart = startOfMonth(new Date(months[0].year, months[0].month - 1, 1));
-  const lastMonth = months[months.length - 1];
-  const lastMonthEnd = endOfMonth(new Date(lastMonth.year, lastMonth.month - 1, 1));
-  if (aEnd < firstMonthStart || aStart > lastMonthEnd) return null;
-  const visibleStart = dateMax([aStart, firstMonthStart]);
-  const visibleEnd = dateMin([aEnd, lastMonthEnd]);
-  const left = getMonthlyPixelPosition(visibleStart, months);
-  const right = getMonthlyPixelPosition(addDays(visibleEnd, 1), months);
-  return { left, width: right - left, visibleStart };
-}
-
-function computeBarPositionWeekly(
-  item: DateRange,
-  allDays: DayInfo[],
-): { left: number; width: number; visibleStart: Date } | null {
-  if (allDays.length === 0) return null;
-  const aStart = parseISO(item.start_date);
-  const aEnd = parseISO(item.end_date);
-  const firstDay = allDays[0].date;
-  const lastDay = allDays[allDays.length - 1].date;
-  if (aEnd < firstDay || aStart > lastDay) return null;
-  const visibleStart = dateMax([aStart, firstDay]);
-  const visibleEnd = dateMin([aEnd, lastDay]);
-  const leftDays = differenceInCalendarDays(visibleStart, firstDay);
-  const spanDays = differenceInCalendarDays(visibleEnd, visibleStart) + 1;
-  return { left: leftDays * DAY_WIDTH, width: spanDays * DAY_WIDTH, visibleStart };
-}
-
-function getResizeHandleVisibility(
-  assignment: { start_date: string; end_date: string },
-  isWeekly: boolean,
-  months: MonthDef[],
-  allDays: DayInfo[],
-): { showResizeLeft: boolean; showResizeRight: boolean } {
-  if (isWeekly) {
-    if (allDays.length === 0) return { showResizeLeft: false, showResizeRight: false };
-    return {
-      showResizeLeft: assignment.start_date >= allDays[0].key,
-      showResizeRight: assignment.end_date <= allDays[allDays.length - 1].key,
-    };
-  }
-  if (months.length === 0) return { showResizeLeft: false, showResizeRight: false };
-  const firstKey = format(
-    startOfMonth(new Date(months[0].year, months[0].month - 1, 1)),
-    "yyyy-MM-dd",
-  );
-  const lastM = months[months.length - 1];
-  const lastKey = format(endOfMonth(new Date(lastM.year, lastM.month - 1, 1)), "yyyy-MM-dd");
-  return {
-    showResizeLeft: assignment.start_date >= firstKey,
-    showResizeRight: assignment.end_date <= lastKey,
-  };
-}
-
-function assignRow(
-  pos: { left: number; width: number },
-  occupiedRows: { left: number; right: number; row: number }[],
-): number {
-  let row = 0;
-  const right = pos.left + pos.width;
-  while (occupiedRows.some((o) => o.row === row && pos.left < o.right && right > o.left)) {
-    row++;
-  }
-  occupiedRows.push({ left: pos.left, right, row });
-  return row;
-}
+import {
+  getDateFromMonthlyPixelPosition,
+  computeBarPositionMonthly,
+  computeBarPositionWeekly,
+  getResizeHandleVisibility,
+  assignRow,
+} from "@/lib/timelineLayout";
 
 interface ProjectTimelineRowProps {
   project: ProjectTimelineProject;

--- a/frontend/src/components/timeline/TimelineRow.tsx
+++ b/frontend/src/components/timeline/TimelineRow.tsx
@@ -4,177 +4,22 @@ import {
   endOfMonth,
   differenceInCalendarDays,
   parseISO,
-  max as dateMax,
-  min as dateMin,
   isWithinInterval,
-  addDays,
   format,
 } from "date-fns";
 import { Badge } from "@/components/ui/badge";
 import type { TimelineAssignment, VacationInfo } from "@/types/assignment";
-import type {
-  TimelineRowProps,
-  MonthDef,
-  DateRange,
-  DayInfo,
-  WeekInfo,
-} from "@/types/timeline";
+import type { TimelineRowProps, DateRange, WeekInfo } from "@/types/timeline";
 import { TEAM_LABELS, LEAVE_TYPE_LABELS, getUtilColor } from "@/lib/constants";
+import {
+  getDateFromMonthlyPixelPosition,
+  computeBarPositionMonthly,
+  computeBarPositionWeekly,
+  getResizeHandleVisibility,
+  assignRow,
+} from "@/lib/timelineLayout";
 import { TimelineBar } from "./TimelineBar";
 import { MONTH_WIDTH, DAY_WIDTH } from "./TimelineHeader";
-
-function getMonthlyPixelPosition(date: Date, months: MonthDef[]): number {
-  const monthIndex = months.findIndex(
-    (m) => m.year === date.getFullYear() && m.month === date.getMonth() + 1,
-  );
-  if (monthIndex < 0) {
-    if (date < startOfMonth(new Date(months[0].year, months[0].month - 1, 1)))
-      return 0;
-    return months.length * MONTH_WIDTH;
-  }
-  const monthStart = startOfMonth(date);
-  const monthEnd = endOfMonth(date);
-  const daysInMonth = differenceInCalendarDays(monthEnd, monthStart) + 1;
-  const dayOffset = differenceInCalendarDays(date, monthStart);
-  return monthIndex * MONTH_WIDTH + (dayOffset / daysInMonth) * MONTH_WIDTH;
-}
-
-function getDateFromMonthlyPixelPosition(
-  timelineX: number,
-  months: MonthDef[],
-): Date {
-  if (months.length === 0) {
-    return new Date();
-  }
-  const maxX = months.length * MONTH_WIDTH;
-  const clampedX = Math.max(0, Math.min(timelineX, maxX - Number.EPSILON));
-  const monthIndex = Math.min(
-    Math.floor(clampedX / MONTH_WIDTH),
-    months.length - 1,
-  );
-  const m = months[monthIndex];
-  const monthStart = startOfMonth(new Date(m.year, m.month - 1, 1));
-  const monthEnd = endOfMonth(monthStart);
-  const daysInMonth = differenceInCalendarDays(monthEnd, monthStart) + 1;
-  const relWithinMonth = clampedX - monthIndex * MONTH_WIDTH;
-  const dayOffset = Math.min(
-    Math.floor((relWithinMonth / MONTH_WIDTH) * daysInMonth),
-    daysInMonth - 1,
-  );
-  return addDays(monthStart, dayOffset);
-}
-
-function computeBarPositionMonthly(
-  item: DateRange,
-  months: MonthDef[],
-): { left: number; width: number; visibleStart: Date } | null {
-  if (months.length === 0) return null;
-
-  const aStart = parseISO(item.start_date);
-  const aEnd = parseISO(item.end_date);
-
-  const firstMonthStart = startOfMonth(
-    new Date(months[0].year, months[0].month - 1, 1),
-  );
-  const lastMonth = months[months.length - 1];
-  const lastMonthEnd = endOfMonth(
-    new Date(lastMonth.year, lastMonth.month - 1, 1),
-  );
-
-  if (aEnd < firstMonthStart || aStart > lastMonthEnd) return null;
-
-  const visibleStart = dateMax([aStart, firstMonthStart]);
-  const visibleEnd = dateMin([aEnd, lastMonthEnd]);
-
-  const left = getMonthlyPixelPosition(visibleStart, months);
-  const right = getMonthlyPixelPosition(addDays(visibleEnd, 1), months);
-
-  return {
-    left,
-    width: right - left,
-    visibleStart,
-  };
-}
-
-function computeBarPositionWeekly(
-  item: DateRange,
-  allDays: DayInfo[],
-): { left: number; width: number; visibleStart: Date } | null {
-  if (allDays.length === 0) return null;
-
-  const aStart = parseISO(item.start_date);
-  const aEnd = parseISO(item.end_date);
-
-  const firstDay = allDays[0].date;
-  const lastDay = allDays[allDays.length - 1].date;
-
-  if (aEnd < firstDay || aStart > lastDay) return null;
-
-  const visibleStart = dateMax([aStart, firstDay]);
-  const visibleEnd = dateMin([aEnd, lastDay]);
-
-  const leftDays = differenceInCalendarDays(visibleStart, firstDay);
-  const spanDays = differenceInCalendarDays(visibleEnd, visibleStart) + 1;
-
-  return {
-    left: leftDays * DAY_WIDTH,
-    width: spanDays * DAY_WIDTH,
-    visibleStart,
-  };
-}
-
-function getResizeHandleVisibility(
-  assignment: TimelineAssignment,
-  isWeekly: boolean,
-  months: MonthDef[],
-  allDays: DayInfo[],
-): { showResizeLeft: boolean; showResizeRight: boolean } {
-  if (isWeekly) {
-    if (allDays.length === 0) {
-      return { showResizeLeft: false, showResizeRight: false };
-    }
-    const firstKey = allDays[0].key;
-    const lastKey = allDays[allDays.length - 1].key;
-    return {
-      showResizeLeft: assignment.start_date >= firstKey,
-      showResizeRight: assignment.end_date <= lastKey,
-    };
-  }
-  if (months.length === 0) {
-    return { showResizeLeft: false, showResizeRight: false };
-  }
-  const firstKey = format(
-    startOfMonth(new Date(months[0].year, months[0].month - 1, 1)),
-    "yyyy-MM-dd",
-  );
-  const lastM = months[months.length - 1];
-  const lastKey = format(
-    endOfMonth(new Date(lastM.year, lastM.month - 1, 1)),
-    "yyyy-MM-dd",
-  );
-  return {
-    showResizeLeft: assignment.start_date >= firstKey,
-    showResizeRight: assignment.end_date <= lastKey,
-  };
-}
-
-/** Find the first non-overlapping row for a bar and register it. */
-function assignRow(
-  pos: { left: number; width: number },
-  occupiedRows: { left: number; right: number; row: number }[],
-): number {
-  let row = 0;
-  const right = pos.left + pos.width;
-  while (
-    occupiedRows.some(
-      (o) => o.row === row && pos.left < o.right && right > o.left,
-    )
-  ) {
-    row++;
-  }
-  occupiedRows.push({ left: pos.left, right, row });
-  return row;
-}
 
 /** Compute weekly utilization % from assignments, accounting for vacations. */
 function computeWeeklyUtilization(

--- a/frontend/src/hooks/useProjectTimeline.ts
+++ b/frontend/src/hooks/useProjectTimeline.ts
@@ -1,0 +1,95 @@
+import { useQuery } from "@tanstack/react-query";
+import { useDebouncedValue } from "./useDebouncedValue";
+import { addMonths, addWeeks, format, addDays, getISOWeek, getDay } from "date-fns";
+import { pl } from "date-fns/locale";
+import { fetchProjectTimeline } from "@/api/projectTimeline";
+import { useProjectTimelineStore } from "@/stores/projectTimelineStore";
+import type { DayInfo, WeekInfo } from "@/types/timeline";
+
+const MONTHS_VISIBLE = 7;
+const WEEKS_VISIBLE = 6;
+const DAY_LABELS = ["Nd", "Pn", "Wt", "Śr", "Czw", "Pt", "Sb"];
+
+function generateWeeks(start: Date, count: number): WeekInfo[] {
+  const weeks: WeekInfo[] = [];
+  let current = new Date(start);
+
+  for (let w = 0; w < count; w++) {
+    const weekStart = current;
+    const weekEnd = addDays(weekStart, 6);
+    const weekNum = getISOWeek(weekStart);
+
+    const days: DayInfo[] = [];
+    for (let d = 0; d < 7; d++) {
+      const day = addDays(weekStart, d);
+      const dow = getDay(day);
+      days.push({
+        date: day,
+        key: format(day, "yyyy-MM-dd"),
+        dayOfWeek: dow === 0 ? 7 : dow,
+        label: DAY_LABELS[dow],
+        isWeekend: dow === 0 || dow === 6,
+      });
+    }
+
+    const startLabel = format(weekStart, "d", { locale: pl });
+    const endLabel = format(weekEnd, "d MMM", { locale: pl });
+
+    weeks.push({
+      weekNumber: weekNum,
+      label: `${startLabel}-${endLabel}`,
+      days,
+    });
+
+    current = addWeeks(current, 1);
+  }
+
+  return weeks;
+}
+
+export function useProjectTimeline() {
+  const { startDate, searchQuery, viewMode } = useProjectTimelineStore();
+  const debouncedSearch = useDebouncedValue(searchQuery.trim(), 300);
+
+  const endDate =
+    viewMode === "monthly"
+      ? addMonths(startDate, MONTHS_VISIBLE)
+      : addWeeks(startDate, WEEKS_VISIBLE);
+
+  const startStr = format(startDate, "yyyy-MM-dd");
+  const endStr = format(endDate, "yyyy-MM-dd");
+
+  const query = useQuery({
+    queryKey: ["project-timeline", startStr, endStr, debouncedSearch, viewMode],
+    queryFn: () => fetchProjectTimeline(startStr, endStr, debouncedSearch || undefined),
+  });
+
+  const months: { year: number; month: number; label: string; key: string }[] = [];
+  if (viewMode === "monthly") {
+    let current = new Date(startDate);
+    for (let i = 0; i < MONTHS_VISIBLE; i++) {
+      months.push({
+        year: current.getFullYear(),
+        month: current.getMonth() + 1,
+        label: format(current, "LLLL yyyy", { locale: pl }),
+        key: format(current, "yyyy-MM"),
+      });
+      current = addMonths(current, 1);
+    }
+  }
+
+  const weeks: WeekInfo[] =
+    viewMode === "weekly" ? generateWeeks(startDate, WEEKS_VISIBLE) : [];
+
+  const allDays: DayInfo[] = weeks.flatMap((w) => w.days);
+
+  return {
+    ...query,
+    months,
+    weeks,
+    allDays,
+    startDate,
+    endDate,
+    viewMode,
+  };
+}

--- a/frontend/src/hooks/useProjectTimeline.ts
+++ b/frontend/src/hooks/useProjectTimeline.ts
@@ -1,51 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { useDebouncedValue } from "./useDebouncedValue";
-import { addMonths, addWeeks, format, addDays, getISOWeek, getDay } from "date-fns";
+import { addMonths, addWeeks, format } from "date-fns";
 import { pl } from "date-fns/locale";
 import { fetchProjectTimeline } from "@/api/projectTimeline";
 import { useProjectTimelineStore } from "@/stores/projectTimelineStore";
+import { generateWeeks } from "@/lib/timelineLayout";
 import type { DayInfo, WeekInfo } from "@/types/timeline";
 
 const MONTHS_VISIBLE = 7;
 const WEEKS_VISIBLE = 6;
-const DAY_LABELS = ["Nd", "Pn", "Wt", "Śr", "Czw", "Pt", "Sb"];
-
-function generateWeeks(start: Date, count: number): WeekInfo[] {
-  const weeks: WeekInfo[] = [];
-  let current = new Date(start);
-
-  for (let w = 0; w < count; w++) {
-    const weekStart = current;
-    const weekEnd = addDays(weekStart, 6);
-    const weekNum = getISOWeek(weekStart);
-
-    const days: DayInfo[] = [];
-    for (let d = 0; d < 7; d++) {
-      const day = addDays(weekStart, d);
-      const dow = getDay(day);
-      days.push({
-        date: day,
-        key: format(day, "yyyy-MM-dd"),
-        dayOfWeek: dow === 0 ? 7 : dow,
-        label: DAY_LABELS[dow],
-        isWeekend: dow === 0 || dow === 6,
-      });
-    }
-
-    const startLabel = format(weekStart, "d", { locale: pl });
-    const endLabel = format(weekEnd, "d MMM", { locale: pl });
-
-    weeks.push({
-      weekNumber: weekNum,
-      label: `${startLabel}-${endLabel}`,
-      days,
-    });
-
-    current = addWeeks(current, 1);
-  }
-
-  return weeks;
-}
 
 export function useProjectTimeline() {
   const { startDate, searchQuery, viewMode } = useProjectTimelineStore();

--- a/frontend/src/hooks/useTimeline.ts
+++ b/frontend/src/hooks/useTimeline.ts
@@ -1,59 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { useDebouncedValue } from "./useDebouncedValue";
-import {
-  addMonths,
-  addDays,
-  addWeeks,
-  format,
-  getISOWeek,
-  getDay,
-  parseISO,
-} from "date-fns";
+import { addMonths, addWeeks, format, parseISO } from "date-fns";
 import { pl } from "date-fns/locale";
 import { fetchTimeline } from "@/api/assignments";
 import { useTimelineStore } from "@/stores/timelineStore";
+import { generateWeeks } from "@/lib/timelineLayout";
 import type { DayInfo, WeekInfo } from "@/types/timeline";
 
 const MONTHS_VISIBLE = 7;
 const WEEKS_VISIBLE = 6;
-const DAY_LABELS = ["Nd", "Pn", "Wt", "Śr", "Czw", "Pt", "Sb"];
-
-function generateWeeks(start: Date, count: number): WeekInfo[] {
-  const weeks: WeekInfo[] = [];
-  let current = new Date(start);
-
-  for (let w = 0; w < count; w++) {
-    const weekStart = current;
-    const weekEnd = addDays(weekStart, 6);
-    const weekNum = getISOWeek(weekStart);
-
-    const days: DayInfo[] = [];
-    for (let d = 0; d < 7; d++) {
-      const day = addDays(weekStart, d);
-      const dow = getDay(day); // 0=Sun, 1=Mon, ...
-      days.push({
-        date: day,
-        key: format(day, "yyyy-MM-dd"),
-        dayOfWeek: dow === 0 ? 7 : dow, // ISO: 1=Mon, 7=Sun
-        label: DAY_LABELS[dow],
-        isWeekend: dow === 0 || dow === 6,
-      });
-    }
-
-    const startLabel = format(weekStart, "d", { locale: pl });
-    const endLabel = format(weekEnd, "d MMM", { locale: pl });
-
-    weeks.push({
-      weekNumber: weekNum,
-      label: `${startLabel}-${endLabel}`,
-      days,
-    });
-
-    current = addWeeks(current, 1);
-  }
-
-  return weeks;
-}
 
 export function useTimeline() {
   const { startDate, selectedTeams, searchQuery, viewMode, utilizationFilter } =

--- a/frontend/src/lib/timelineLayout.ts
+++ b/frontend/src/lib/timelineLayout.ts
@@ -1,0 +1,220 @@
+import {
+  startOfMonth,
+  endOfMonth,
+  differenceInCalendarDays,
+  parseISO,
+  max as dateMax,
+  min as dateMin,
+  addDays,
+  addWeeks,
+  format,
+  getISOWeek,
+  getDay,
+} from "date-fns";
+import { pl } from "date-fns/locale";
+import type { MonthDef, DateRange, DayInfo, WeekInfo } from "@/types/timeline";
+import { MONTH_WIDTH, DAY_WIDTH } from "@/components/timeline/TimelineHeader";
+
+const DAY_LABELS = ["Nd", "Pn", "Wt", "Śr", "Czw", "Pt", "Sb"];
+
+export interface BarPosition {
+  left: number;
+  width: number;
+  visibleStart: Date;
+}
+
+/** Pixel X of a date on the monthly timeline (proportional within each month column). */
+export function getMonthlyPixelPosition(date: Date, months: MonthDef[]): number {
+  const monthIndex = months.findIndex(
+    (m) => m.year === date.getFullYear() && m.month === date.getMonth() + 1,
+  );
+  if (monthIndex < 0) {
+    if (date < startOfMonth(new Date(months[0].year, months[0].month - 1, 1)))
+      return 0;
+    return months.length * MONTH_WIDTH;
+  }
+  const monthStart = startOfMonth(date);
+  const monthEnd = endOfMonth(date);
+  const daysInMonth = differenceInCalendarDays(monthEnd, monthStart) + 1;
+  const dayOffset = differenceInCalendarDays(date, monthStart);
+  return monthIndex * MONTH_WIDTH + (dayOffset / daysInMonth) * MONTH_WIDTH;
+}
+
+/** Inverse of getMonthlyPixelPosition: pixel X on the monthly timeline → date. */
+export function getDateFromMonthlyPixelPosition(
+  timelineX: number,
+  months: MonthDef[],
+): Date {
+  if (months.length === 0) {
+    return new Date();
+  }
+  const maxX = months.length * MONTH_WIDTH;
+  const clampedX = Math.max(0, Math.min(timelineX, maxX - Number.EPSILON));
+  const monthIndex = Math.min(
+    Math.floor(clampedX / MONTH_WIDTH),
+    months.length - 1,
+  );
+  const m = months[monthIndex];
+  const monthStart = startOfMonth(new Date(m.year, m.month - 1, 1));
+  const monthEnd = endOfMonth(monthStart);
+  const daysInMonth = differenceInCalendarDays(monthEnd, monthStart) + 1;
+  const relWithinMonth = clampedX - monthIndex * MONTH_WIDTH;
+  const dayOffset = Math.min(
+    Math.floor((relWithinMonth / MONTH_WIDTH) * daysInMonth),
+    daysInMonth - 1,
+  );
+  return addDays(monthStart, dayOffset);
+}
+
+/** Bar position (left/width) for a date range on the monthly timeline, or null if outside. */
+export function computeBarPositionMonthly(
+  item: DateRange,
+  months: MonthDef[],
+): BarPosition | null {
+  if (months.length === 0) return null;
+
+  const aStart = parseISO(item.start_date);
+  const aEnd = parseISO(item.end_date);
+
+  const firstMonthStart = startOfMonth(
+    new Date(months[0].year, months[0].month - 1, 1),
+  );
+  const lastMonth = months[months.length - 1];
+  const lastMonthEnd = endOfMonth(
+    new Date(lastMonth.year, lastMonth.month - 1, 1),
+  );
+
+  if (aEnd < firstMonthStart || aStart > lastMonthEnd) return null;
+
+  const visibleStart = dateMax([aStart, firstMonthStart]);
+  const visibleEnd = dateMin([aEnd, lastMonthEnd]);
+
+  const left = getMonthlyPixelPosition(visibleStart, months);
+  const right = getMonthlyPixelPosition(addDays(visibleEnd, 1), months);
+
+  return {
+    left,
+    width: right - left,
+    visibleStart,
+  };
+}
+
+/** Bar position (left/width) for a date range on the weekly timeline, or null if outside. */
+export function computeBarPositionWeekly(
+  item: DateRange,
+  allDays: DayInfo[],
+): BarPosition | null {
+  if (allDays.length === 0) return null;
+
+  const aStart = parseISO(item.start_date);
+  const aEnd = parseISO(item.end_date);
+
+  const firstDay = allDays[0].date;
+  const lastDay = allDays[allDays.length - 1].date;
+
+  if (aEnd < firstDay || aStart > lastDay) return null;
+
+  const visibleStart = dateMax([aStart, firstDay]);
+  const visibleEnd = dateMin([aEnd, lastDay]);
+
+  const leftDays = differenceInCalendarDays(visibleStart, firstDay);
+  const spanDays = differenceInCalendarDays(visibleEnd, visibleStart) + 1;
+
+  return {
+    left: leftDays * DAY_WIDTH,
+    width: spanDays * DAY_WIDTH,
+    visibleStart,
+  };
+}
+
+/** Whether resize handles should be shown for a bar (hidden when the true edge is off-screen). */
+export function getResizeHandleVisibility(
+  assignment: DateRange,
+  isWeekly: boolean,
+  months: MonthDef[],
+  allDays: DayInfo[],
+): { showResizeLeft: boolean; showResizeRight: boolean } {
+  if (isWeekly) {
+    if (allDays.length === 0) {
+      return { showResizeLeft: false, showResizeRight: false };
+    }
+    const firstKey = allDays[0].key;
+    const lastKey = allDays[allDays.length - 1].key;
+    return {
+      showResizeLeft: assignment.start_date >= firstKey,
+      showResizeRight: assignment.end_date <= lastKey,
+    };
+  }
+  if (months.length === 0) {
+    return { showResizeLeft: false, showResizeRight: false };
+  }
+  const firstKey = format(
+    startOfMonth(new Date(months[0].year, months[0].month - 1, 1)),
+    "yyyy-MM-dd",
+  );
+  const lastM = months[months.length - 1];
+  const lastKey = format(
+    endOfMonth(new Date(lastM.year, lastM.month - 1, 1)),
+    "yyyy-MM-dd",
+  );
+  return {
+    showResizeLeft: assignment.start_date >= firstKey,
+    showResizeRight: assignment.end_date <= lastKey,
+  };
+}
+
+/** Find the first non-overlapping row for a bar and register it. */
+export function assignRow(
+  pos: { left: number; width: number },
+  occupiedRows: { left: number; right: number; row: number }[],
+): number {
+  let row = 0;
+  const right = pos.left + pos.width;
+  while (
+    occupiedRows.some(
+      (o) => o.row === row && pos.left < o.right && right > o.left,
+    )
+  ) {
+    row++;
+  }
+  occupiedRows.push({ left: pos.left, right, row });
+  return row;
+}
+
+/** Generate `count` consecutive weeks (7 days each) starting at `start`. */
+export function generateWeeks(start: Date, count: number): WeekInfo[] {
+  const weeks: WeekInfo[] = [];
+  let current = new Date(start);
+
+  for (let w = 0; w < count; w++) {
+    const weekStart = current;
+    const weekEnd = addDays(weekStart, 6);
+    const weekNum = getISOWeek(weekStart);
+
+    const days: DayInfo[] = [];
+    for (let d = 0; d < 7; d++) {
+      const day = addDays(weekStart, d);
+      const dow = getDay(day); // 0=Sun, 1=Mon, ...
+      days.push({
+        date: day,
+        key: format(day, "yyyy-MM-dd"),
+        dayOfWeek: dow === 0 ? 7 : dow, // ISO: 1=Mon, 7=Sun
+        label: DAY_LABELS[dow],
+        isWeekend: dow === 0 || dow === 6,
+      });
+    }
+
+    const startLabel = format(weekStart, "d", { locale: pl });
+    const endLabel = format(weekEnd, "d MMM", { locale: pl });
+
+    weeks.push({
+      weekNumber: weekNum,
+      label: `${startLabel}-${endLabel}`,
+      days,
+    });
+
+    current = addWeeks(current, 1);
+  }
+
+  return weeks;
+}

--- a/frontend/src/stores/projectTimelineStore.ts
+++ b/frontend/src/stores/projectTimelineStore.ts
@@ -1,0 +1,62 @@
+import { create } from "zustand";
+import {
+  startOfMonth,
+  addMonths,
+  subMonths,
+  startOfWeek,
+  addWeeks,
+  subWeeks,
+} from "date-fns";
+import type { ViewMode } from "@/types/timeline";
+
+interface ProjectTimelineState {
+  viewMode: ViewMode;
+  startDate: Date;
+  searchQuery: string;
+  setViewMode: (mode: ViewMode) => void;
+  setStartDate: (date: Date) => void;
+  setSearchQuery: (query: string) => void;
+  scrollForward: () => void;
+  scrollBack: () => void;
+  goToToday: () => void;
+}
+
+function snapToMode(date: Date, mode: ViewMode): Date {
+  return mode === "weekly"
+    ? startOfWeek(date, { weekStartsOn: 1 })
+    : startOfMonth(date);
+}
+
+export const useProjectTimelineStore = create<ProjectTimelineState>((set) => ({
+  viewMode: "monthly",
+  startDate: subMonths(startOfMonth(new Date()), 1),
+  searchQuery: "",
+
+  setViewMode: (mode) =>
+    set((state) => ({
+      viewMode: mode,
+      startDate: snapToMode(state.startDate, mode),
+    })),
+  setStartDate: (date) =>
+    set((state) => ({ startDate: snapToMode(date, state.viewMode) })),
+  setSearchQuery: (query) => set({ searchQuery: query }),
+
+  scrollForward: () =>
+    set((state) => ({
+      startDate:
+        state.viewMode === "monthly"
+          ? addMonths(state.startDate, 1)
+          : addWeeks(state.startDate, 1),
+    })),
+
+  scrollBack: () =>
+    set((state) => ({
+      startDate:
+        state.viewMode === "monthly"
+          ? subMonths(state.startDate, 1)
+          : subWeeks(state.startDate, 1),
+    })),
+
+  goToToday: () =>
+    set((state) => ({ startDate: snapToMode(new Date(), state.viewMode) })),
+}));

--- a/frontend/src/types/assignment.ts
+++ b/frontend/src/types/assignment.ts
@@ -70,6 +70,7 @@ export interface AssignmentModalProps {
   onClose: () => void;
   assignment?: TimelineAssignment | null;
   defaultEmployeeId?: number | null;
+  defaultProjectId?: number | null;
   defaultStartDate?: string | null;
 }
 

--- a/frontend/src/types/project-timeline.ts
+++ b/frontend/src/types/project-timeline.ts
@@ -1,0 +1,28 @@
+import type { HolidayInfo } from "./assignment";
+
+export interface ProjectTimelineAssignment {
+  id: number;
+  employee_id: number;
+  employee_name: string;
+  employee_team: string | null;
+  start_date: string;
+  end_date: string;
+  allocation_type: string;
+  allocation_value: number;
+  note: string | null;
+  is_tentative: boolean;
+  daily_hours: number;
+}
+
+export interface ProjectTimelineProject {
+  id: number;
+  name: string;
+  color: string;
+  assignments: ProjectTimelineAssignment[];
+}
+
+export interface ProjectTimelineData {
+  projects: ProjectTimelineProject[];
+  holidays: HolidayInfo[];
+  working_days_per_month: Record<string, number>;
+}


### PR DESCRIPTION
## Summary

New independent **Project Timeline** view at `/project-timeline` — rows are projects, bars show employee name and allocation. Analogous to the employee Timeline but without utilization indicators or vacation bars.

- Left panel: active, non-deleted projects (color dot + name)
- Bars: assignments labeled with employee name and allocation percentage
- Monthly / weekly view toggle, date navigation, project name search, visible project count
- Full edit support: create, edit, delete, drag between projects, resize, split, duplicate
- Click empty slot → modal with project pre-filled; click bar → modal with employee pre-filled
- Assignments for soft-deleted employees are excluded from the response

## Changes

**Backend**
- `backend/app/api/project_timeline.py` — new `GET /api/projects/timeline` endpoint; groups by project, batch-fetches assignments with selectin employee loading, filters out assignments for deleted employees
- `backend/app/main.py` — registers the new router

**Frontend**
- `src/components/project-timeline/` — three new components: `ProjectTimeline`, `ProjectTimelineFilters`, `ProjectTimelineRow`
- `src/hooks/useProjectTimeline.ts`, `src/stores/projectTimelineStore.ts` — store and hook mirroring the employee timeline (without utilizationFilter)
- `src/types/project-timeline.ts`, `src/api/projectTimeline.ts` — types and fetch function
- `AssignmentModal` — added `defaultProjectId` prop; mutations invalidate `["project-timeline"]` cache
- `App.tsx` + `Sidebar.tsx` — new route and nav item with GanttChart icon (all roles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)