### PR TITLE
feat: placeholder assignments (unassigned planned work)

### DIFF
--- a/backend/alembic/versions/l2a3b4c5d6e7_make_assignment_employee_id_nullable.py
+++ b/backend/alembic/versions/l2a3b4c5d6e7_make_assignment_employee_id_nullable.py
@@ -1,0 +1,42 @@
+"""make_assignment_employee_id_nullable
+
+Allow NULL employee_id on assignments to support "placeholder" assignments —
+planned work on a project that is not yet allocated to a specific person.
+
+Revision ID: l2a3b4c5d6e7
+Revises: k1f2a3b4c5d6
+Create Date: 2026-07-21 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'l2a3b4c5d6e7'
+down_revision: Union[str, Sequence[str], None] = 'k1f2a3b4c5d6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        'assignments',
+        'employee_id',
+        existing_type=sa.Integer(),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    # Placeholder assignments (employee_id IS NULL) cannot exist under the old
+    # schema; remove them before restoring the NOT NULL constraint.
+    op.execute("DELETE FROM assignments WHERE employee_id IS NULL")
+    op.alter_column(
+        'assignments',
+        'employee_id',
+        existing_type=sa.Integer(),
+        nullable=False,
+    )

--- a/backend/app/api/assignments.py
+++ b/backend/app/api/assignments.py
@@ -92,14 +92,15 @@ async def create_assignment(
             status_code=400, detail="Assignment must contain at least 1 working day"
         )
 
-    # Validate employee exists
-    emp = await db.execute(
-        select(Employee).where(
-            Employee.id == body.employee_id, Employee.is_deleted == False
+    # Validate employee exists (skipped for placeholder assignments, employee_id is None)
+    if body.employee_id is not None:
+        emp = await db.execute(
+            select(Employee).where(
+                Employee.id == body.employee_id, Employee.is_deleted == False
+            )
         )
-    )
-    if not emp.scalar_one_or_none():
-        raise HTTPException(status_code=404, detail="Employee not found")
+        if not emp.scalar_one_or_none():
+            raise HTTPException(status_code=404, detail="Employee not found")
 
     # Validate project exists and is not archived
     proj = await db.execute(
@@ -144,15 +145,19 @@ async def update_assignment(
     if not assignment:
         raise HTTPException(status_code=404, detail="Assignment not found")
 
-    if body.employee_id is not None:
-        emp = await db.execute(
-            select(Employee).where(
-                Employee.id == body.employee_id, Employee.is_deleted == False
+    if "employee_id" in body.model_fields_set:
+        if body.employee_id is None:
+            # Explicitly un-assign: turn the assignment back into a placeholder.
+            assignment.employee_id = None
+        else:
+            emp = await db.execute(
+                select(Employee).where(
+                    Employee.id == body.employee_id, Employee.is_deleted == False
+                )
             )
-        )
-        if not emp.scalar_one_or_none():
-            raise HTTPException(status_code=404, detail="Employee not found")
-        assignment.employee_id = body.employee_id
+            if not emp.scalar_one_or_none():
+                raise HTTPException(status_code=404, detail="Employee not found")
+            assignment.employee_id = body.employee_id
 
     if body.project_id is not None:
         proj = await db.execute(
@@ -264,13 +269,15 @@ async def duplicate_assignment(
         raise HTTPException(status_code=404, detail="Assignment not found")
 
     # Validate employee and project are not soft-deleted
-    emp = await db.execute(
-        select(Employee).where(
-            Employee.id == assignment.employee_id, Employee.is_deleted == False
+    # (placeholder assignments have no employee, so skip the employee check)
+    if assignment.employee_id is not None:
+        emp = await db.execute(
+            select(Employee).where(
+                Employee.id == assignment.employee_id, Employee.is_deleted == False
+            )
         )
-    )
-    if not emp.scalar_one_or_none():
-        raise HTTPException(status_code=400, detail="Cannot duplicate: employee has been deleted")
+        if not emp.scalar_one_or_none():
+            raise HTTPException(status_code=400, detail="Cannot duplicate: employee has been deleted")
 
     proj = await db.execute(
         select(Project).where(

--- a/backend/app/api/calendar.py
+++ b/backend/app/api/calendar.py
@@ -27,6 +27,36 @@ from app.utils.working_days import get_working_days, get_working_days_in_month
 router = APIRouter(tags=["calendar"])
 
 
+def _serialize_timeline_assignment(a: Assignment, range_start: date) -> dict:
+    """Serialize an assignment for the timeline response.
+
+    daily_hours is computed for the first month of the assignment visible in
+    the requested range (assignments starting before the range use range_start).
+    """
+    first_month_date = max(a.start_date, range_start)
+    daily = calculate_daily_hours(
+        a.allocation_type.value,
+        a.allocation_value,
+        first_month_date.year,
+        first_month_date.month,
+        start_date=a.start_date,
+        end_date=a.end_date,
+    )
+    return {
+        "id": a.id,
+        "project_id": a.project_id,
+        "project_name": a.project.name if a.project else "",
+        "project_color": a.project.color if a.project else "#000000",
+        "start_date": a.start_date.isoformat(),
+        "end_date": a.end_date.isoformat(),
+        "allocation_type": a.allocation_type.value,
+        "allocation_value": float(a.allocation_value),
+        "note": a.note,
+        "is_tentative": a.is_tentative,
+        "daily_hours": float(round(daily, 2)),
+    }
+
+
 def _parse_id_csv(raw: str) -> list[int]:
     """Parse a comma-separated list of integer ids, raising 400 on bad input."""
     ids: list[int] = []
@@ -150,33 +180,9 @@ async def get_timeline(
     for emp in employees:
         assignments = assignments_by_employee[emp.id]
 
-        assignment_list = []
-        for a in assignments:
-            # Use first month of assignment for daily_hours display
-            first_month_year = max(a.start_date, start_date)
-            daily = calculate_daily_hours(
-                a.allocation_type.value,
-                a.allocation_value,
-                first_month_year.year,
-                first_month_year.month,
-                start_date=a.start_date,
-                end_date=a.end_date,
-            )
-            assignment_list.append(
-                {
-                    "id": a.id,
-                    "project_id": a.project_id,
-                    "project_name": a.project.name if a.project else "",
-                    "project_color": a.project.color if a.project else "#000000",
-                    "start_date": a.start_date.isoformat(),
-                    "end_date": a.end_date.isoformat(),
-                    "allocation_type": a.allocation_type.value,
-                    "allocation_value": float(a.allocation_value),
-                    "note": a.note,
-                    "is_tentative": a.is_tentative,
-                    "daily_hours": float(round(daily, 2)),
-                }
-            )
+        assignment_list = [
+            _serialize_timeline_assignment(a, start_date) for a in assignments
+        ]
 
         # Employee vacations
         emp_vacations = vacations_by_employee.get(emp.id, [])
@@ -221,32 +227,10 @@ async def get_timeline(
         )
 
     # Build placeholder (unassigned) assignments list
-    placeholder_list = []
-    for a in placeholder_assignments:
-        first_month_date = max(a.start_date, start_date)
-        daily = calculate_daily_hours(
-            a.allocation_type.value,
-            a.allocation_value,
-            first_month_date.year,
-            first_month_date.month,
-            start_date=a.start_date,
-            end_date=a.end_date,
-        )
-        placeholder_list.append(
-            {
-                "id": a.id,
-                "project_id": a.project_id,
-                "project_name": a.project.name if a.project else "",
-                "project_color": a.project.color if a.project else "#000000",
-                "start_date": a.start_date.isoformat(),
-                "end_date": a.end_date.isoformat(),
-                "allocation_type": a.allocation_type.value,
-                "allocation_value": float(a.allocation_value),
-                "note": a.note,
-                "is_tentative": a.is_tentative,
-                "daily_hours": float(round(daily, 2)),
-            }
-        )
+    placeholder_list = [
+        _serialize_timeline_assignment(a, start_date)
+        for a in placeholder_assignments
+    ]
 
     return {
         "employees": employee_data,

--- a/backend/app/api/calendar.py
+++ b/backend/app/api/calendar.py
@@ -128,6 +128,20 @@ async def get_timeline(
         for a in a_result.scalars().all():
             assignments_by_employee[a.employee_id].append(a)
 
+    # Fetch placeholder assignments (no employee yet) in range. These are shown
+    # in a synthetic "unassigned" row on the frontend, independent of employee
+    # filters (they belong to no team/employee).
+    ph_result = await db.execute(
+        select(Assignment)
+        .where(
+            Assignment.employee_id.is_(None),
+            Assignment.start_date <= end_date,
+            Assignment.end_date >= start_date,
+        )
+        .order_by(Assignment.start_date)
+    )
+    placeholder_assignments = ph_result.scalars().all()
+
     # Get vacation sync status
     sync_status = await _get_vacation_sync_status(db)
 
@@ -206,8 +220,37 @@ async def get_timeline(
             }
         )
 
+    # Build placeholder (unassigned) assignments list
+    placeholder_list = []
+    for a in placeholder_assignments:
+        first_month_date = max(a.start_date, start_date)
+        daily = calculate_daily_hours(
+            a.allocation_type.value,
+            a.allocation_value,
+            first_month_date.year,
+            first_month_date.month,
+            start_date=a.start_date,
+            end_date=a.end_date,
+        )
+        placeholder_list.append(
+            {
+                "id": a.id,
+                "project_id": a.project_id,
+                "project_name": a.project.name if a.project else "",
+                "project_color": a.project.color if a.project else "#000000",
+                "start_date": a.start_date.isoformat(),
+                "end_date": a.end_date.isoformat(),
+                "allocation_type": a.allocation_type.value,
+                "allocation_value": float(a.allocation_value),
+                "note": a.note,
+                "is_tentative": a.is_tentative,
+                "daily_hours": float(round(daily, 2)),
+            }
+        )
+
     return {
         "employees": employee_data,
+        "placeholders": placeholder_list,
         "holidays": [
             {"date": d.isoformat(), "name": get_holiday_name(d)}
             for d in holidays_in_range

--- a/backend/app/api/project_timeline.py
+++ b/backend/app/api/project_timeline.py
@@ -69,7 +69,10 @@ async def get_project_timeline(
                 Assignment.project_id.in_(project_ids),
                 Assignment.start_date <= end_date,
                 Assignment.end_date >= start_date,
-                Assignment.employee_id.in_(active_employee_ids),
+                # Include placeholder assignments (employee_id IS NULL) alongside
+                # assignments held by active (non-deleted) employees.
+                Assignment.employee_id.in_(active_employee_ids)
+                | Assignment.employee_id.is_(None),
             )
             .order_by(Assignment.start_date)
         )
@@ -94,9 +97,9 @@ async def get_project_timeline(
             assignment_list.append(
                 {
                     "id": a.id,
-                    "employee_id": emp.id,
-                    "employee_name": f"{emp.last_name} {emp.first_name}",
-                    "employee_team": emp.team.name if emp.team else None,
+                    "employee_id": emp.id if emp else None,
+                    "employee_name": f"{emp.last_name} {emp.first_name}" if emp else None,
+                    "employee_team": emp.team.name if emp and emp.team else None,
                     "start_date": a.start_date.isoformat(),
                     "end_date": a.end_date.isoformat(),
                     "allocation_type": a.allocation_type.value,

--- a/backend/app/models/assignment.py
+++ b/backend/app/models/assignment.py
@@ -21,8 +21,10 @@ class Assignment(Base):
     __tablename__ = "assignments"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    employee_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("employees.id"), nullable=False, index=True
+    # Nullable: a NULL employee_id marks a "placeholder" assignment — work that is
+    # planned on a project but not yet allocated to a specific person.
+    employee_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("employees.id"), nullable=True, index=True
     )
     project_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("projects.id"), nullable=False, index=True

--- a/backend/app/schemas/assignment.py
+++ b/backend/app/schemas/assignment.py
@@ -8,7 +8,8 @@ from pydantic import BaseModel, field_validator, model_validator
 
 
 class AssignmentCreate(BaseModel):
-    employee_id: int
+    # None => placeholder assignment (planned work not yet allocated to a person).
+    employee_id: Optional[int] = None
     project_id: int
     start_date: date
     end_date: date
@@ -72,7 +73,7 @@ class AssignmentUpdate(BaseModel):
 
 class AssignmentResponse(BaseModel):
     id: int
-    employee_id: int
+    employee_id: Optional[int] = None
     project_id: int
     project_name: str
     project_color: str

--- a/backend/tests/test_placeholder_assignments.py
+++ b/backend/tests/test_placeholder_assignments.py
@@ -1,0 +1,154 @@
+"""Tests for placeholder assignments (assignments with employee_id = NULL).
+
+Schema-level tests (no DB), matching the conventions of the other test modules:
+- AssignmentCreate accepts an explicit null / missing employee_id
+- AssignmentUpdate distinguishes "field absent" from "explicit null" via
+  model_fields_set (used by PATCH to un-assign an employee)
+- AssignmentResponse serializes placeholders (employee_id null)
+- The timeline serialization helper handles placeholder assignments
+"""
+
+from datetime import date, datetime
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from app.api.calendar import _serialize_timeline_assignment
+from app.models.assignment import AllocationType, Assignment
+from app.schemas.assignment import (
+    AssignmentCreate,
+    AssignmentResponse,
+    AssignmentUpdate,
+)
+
+
+def _create_defaults(**overrides):
+    base = {
+        "project_id": 1,
+        "start_date": date(2026, 3, 2),
+        "end_date": date(2026, 3, 31),
+        "allocation_type": "percentage",
+        "allocation_value": Decimal("100"),
+    }
+    base.update(overrides)
+    return base
+
+
+class TestAssignmentCreatePlaceholder:
+    def test_explicit_null_employee_id_accepted(self):
+        a = AssignmentCreate(**_create_defaults(employee_id=None))
+        assert a.employee_id is None
+
+    def test_missing_employee_id_defaults_to_none(self):
+        a = AssignmentCreate(**_create_defaults())
+        assert a.employee_id is None
+
+    def test_integer_employee_id_still_accepted(self):
+        a = AssignmentCreate(**_create_defaults(employee_id=7))
+        assert a.employee_id == 7
+
+    def test_placeholder_still_validates_dates(self):
+        """Placeholder creation keeps the regular date-range validation."""
+        with pytest.raises(ValidationError):
+            AssignmentCreate(
+                **_create_defaults(
+                    employee_id=None,
+                    start_date=date(2026, 3, 15),
+                    end_date=date(2026, 3, 1),
+                )
+            )
+
+
+class TestAssignmentUpdateFieldsSet:
+    """PATCH semantics: 'field absent' vs 'explicit null' via model_fields_set."""
+
+    def test_absent_employee_id_not_in_fields_set(self):
+        u = AssignmentUpdate(start_date=date(2026, 3, 1))
+        assert "employee_id" not in u.model_fields_set
+        assert u.employee_id is None
+
+    def test_explicit_null_employee_id_in_fields_set(self):
+        """Explicit null (un-assign to placeholder) is distinguishable from absent."""
+        u = AssignmentUpdate(employee_id=None)
+        assert "employee_id" in u.model_fields_set
+        assert u.employee_id is None
+
+    def test_explicit_employee_id_in_fields_set(self):
+        u = AssignmentUpdate(employee_id=5)
+        assert "employee_id" in u.model_fields_set
+        assert u.employee_id == 5
+
+    def test_json_payload_with_explicit_null(self):
+        """Explicit null survives model_validate of a JSON-style payload."""
+        u = AssignmentUpdate.model_validate({"employee_id": None})
+        assert "employee_id" in u.model_fields_set
+        assert u.employee_id is None
+
+    def test_json_payload_without_employee_id(self):
+        u = AssignmentUpdate.model_validate({"note": "x"})
+        assert "employee_id" not in u.model_fields_set
+
+
+class TestAssignmentResponsePlaceholder:
+    def test_response_accepts_null_employee_id(self):
+        r = AssignmentResponse(
+            id=1,
+            employee_id=None,
+            project_id=2,
+            project_name="Projekt Alpha",
+            project_color="#3B82F6",
+            start_date=date(2026, 3, 2),
+            end_date=date(2026, 3, 31),
+            allocation_type="percentage",
+            allocation_value=100.0,
+            daily_hours=8.0,
+            created_at=datetime(2026, 3, 1, 12, 0, 0),
+        )
+        assert r.employee_id is None
+
+
+class TestSerializeTimelineAssignment:
+    def _placeholder(self, **overrides):
+        base = {
+            "id": 10,
+            "employee_id": None,
+            "project_id": 5,
+            "start_date": date(2026, 3, 2),
+            "end_date": date(2026, 3, 31),
+            "allocation_type": AllocationType.percentage,
+            "allocation_value": Decimal("50"),
+            "note": None,
+            "is_tentative": False,
+        }
+        base.update(overrides)
+        return Assignment(**base)
+
+    def test_placeholder_serialization(self):
+        a = self._placeholder()
+        result = _serialize_timeline_assignment(a, date(2026, 3, 1))
+        assert result == {
+            "id": 10,
+            "project_id": 5,
+            "project_name": "",
+            "project_color": "#000000",
+            "start_date": "2026-03-02",
+            "end_date": "2026-03-31",
+            "allocation_type": "percentage",
+            "allocation_value": 50.0,
+            "note": None,
+            "is_tentative": False,
+            "daily_hours": 4.0,
+        }
+
+    def test_daily_hours_uses_range_start_when_assignment_starts_earlier(self):
+        """monthly_hours daily rate depends on the first visible month."""
+        a = self._placeholder(
+            allocation_type=AllocationType.monthly_hours,
+            allocation_value=Decimal("30"),
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 3, 31),
+        )
+        # Range starts in Feb 2026 (20 working days) => 30h / 20d = 1.5h/day
+        result = _serialize_timeline_assignment(a, date(2026, 2, 1))
+        assert result["daily_hours"] == 1.5

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -68,6 +68,8 @@ DELETE /api/assignments/{id}                # Delete assignment (204)
 
 Assignment response includes: `id`, `employee_id`, `project_id`, `project_name`, `project_color`, `start_date`, `end_date`, `allocation_type`, `allocation_value`, `daily_hours`, `note`, `is_tentative`, `created_at`.
 
+**Placeholder assignments:** `employee_id` is nullable (`int|null`) on create and in responses. `null` marks a *placeholder* — planned work on a project not yet allocated to a specific person. On PATCH, sending an explicit `"employee_id": null` un-assigns the employee (turns the assignment back into a placeholder); omitting the field leaves the employee unchanged.
+
 ## Users (Admin)
 
 ```
@@ -161,6 +163,21 @@ GET /api/assignments/timeline?start_date=2026-01-01&end_date=2026-06-30&teams=Fr
       }
     }
   ],
+  "placeholders": [
+    {
+      "id": 12,
+      "project_id": 5,
+      "project_name": "Projekt Alpha",
+      "project_color": "#3B82F6",
+      "start_date": "2026-02-01",
+      "end_date": "2026-02-28",
+      "allocation_type": "percentage",
+      "allocation_value": 100,
+      "note": "Potrzebny drugi frontend developer",
+      "is_tentative": false,
+      "daily_hours": 8.0
+    }
+  ],
   "holidays": [
     {"date": "2026-01-01", "name": "Nowy Rok"},
     {"date": "2026-01-06", "name": "Trzech Króli"}
@@ -190,7 +207,11 @@ GET /api/assignments/timeline?start_date=2026-01-01&end_date=2026-06-30&teams=Fr
 | `vacations` | array | Vacations within requested date range |
 | `occupancy` | object | Per-period occupancy keyed by "YYYY-MM" (monthly) or "w-YYYY-WW" (weekly) |
 
-**Assignment object (in timeline):**
+**Placeholders:**
+
+`placeholders` is a list of placeholder assignments (`employee_id` is null — planned work not yet allocated to a person) within the requested date range. Each entry has the same shape as the assignment object below. Placeholders are returned regardless of employee filters (`teams`, `search`) since they belong to no employee.
+
+**Assignment object (in timeline and in `placeholders`):**
 
 | Field | Type | Description |
 |---|---|---|
@@ -285,7 +306,7 @@ GET /api/projects/timeline?start_date=2026-01-01&end_date=2026-06-30&search=Alph
 | `id` | int | Project ID |
 | `name` | string | Project name |
 | `color` | string | Hex color |
-| `assignments` | array | Assignments within requested date range (deleted employees excluded) |
+| `assignments` | array | Assignments within requested date range — held by non-deleted employees, plus placeholders (`employee_id` null), which ARE included; assignments of deleted employees are excluded |
 
 Non-deleted projects are always returned (sorted by name), even when they have no assignments in the range.
 
@@ -294,8 +315,8 @@ Non-deleted projects are always returned (sorted by name), even when they have n
 | Field | Type | Description |
 |---|---|---|
 | `id` | int | Assignment ID |
-| `employee_id` | int | Employee ID |
-| `employee_name` | string | "Last First" format |
+| `employee_id` | int\|null | Employee ID (`null` for placeholder assignments) |
+| `employee_name` | string\|null | "Last First" format (`null` for placeholder assignments) |
 | `employee_team` | string\|null | Team enum value |
 | `start_date` | date | Assignment start |
 | `end_date` | date | Assignment end |

--- a/frontend/src/components/assignments/AssignmentFormEmployeeProject.tsx
+++ b/frontend/src/components/assignments/AssignmentFormEmployeeProject.tsx
@@ -15,13 +15,18 @@ export function AssignmentFormEmployeeProject({
   onProjectChange,
   employees,
   projects,
+  employeeError,
 }: AssignmentFormEmployeeProjectProps) {
   return (
     <>
       <div className="space-y-2">
         <Label htmlFor="assignment-employee">Pracownik</Label>
         <Select value={employeeId} onValueChange={onEmployeeChange}>
-          <SelectTrigger id="assignment-employee" className="w-full">
+          <SelectTrigger
+            id="assignment-employee"
+            className="w-full"
+            aria-invalid={!!employeeError}
+          >
             <SelectValue placeholder="Wybierz pracownika" />
           </SelectTrigger>
           <SelectContent>
@@ -35,6 +40,11 @@ export function AssignmentFormEmployeeProject({
             ))}
           </SelectContent>
         </Select>
+        {employeeError && (
+          <p className="text-sm text-destructive" role="alert">
+            {employeeError}
+          </p>
+        )}
       </div>
 
       <div className="space-y-2">

--- a/frontend/src/components/assignments/AssignmentFormEmployeeProject.tsx
+++ b/frontend/src/components/assignments/AssignmentFormEmployeeProject.tsx
@@ -25,6 +25,9 @@ export function AssignmentFormEmployeeProject({
             <SelectValue placeholder="Wybierz pracownika" />
           </SelectTrigger>
           <SelectContent>
+            <SelectItem value="none">
+              — Nieprzypisane (placeholder) —
+            </SelectItem>
             {employees.map((emp) => (
               <SelectItem key={emp.id} value={String(emp.id)}>
                 {emp.last_name} {emp.first_name}

--- a/frontend/src/components/assignments/AssignmentModal.tsx
+++ b/frontend/src/components/assignments/AssignmentModal.tsx
@@ -23,6 +23,7 @@ export function AssignmentModal({
   defaultEmployeeId,
   defaultProjectId,
   defaultStartDate,
+  defaultUnassigned,
 }: AssignmentModalProps) {
   const queryClient = useQueryClient();
   const isEditing = !!assignment;
@@ -83,8 +84,15 @@ export function AssignmentModal({
       setIsTentative(assignment.is_tentative);
     } else {
       // Create mode: no preselected employee means "nothing selected" ("").
-      // Creating a placeholder requires explicitly picking the "none" option.
-      setEmployeeId(defaultEmployeeId != null ? String(defaultEmployeeId) : "");
+      // Creating a placeholder requires explicitly picking the "none" option,
+      // unless the caller already expressed that intent (placeholder row).
+      setEmployeeId(
+        defaultEmployeeId != null
+          ? String(defaultEmployeeId)
+          : defaultUnassigned
+            ? "none"
+            : "",
+      );
       setProjectId(defaultProjectId ? String(defaultProjectId) : "");
       setStartDate(defaultStartDate ?? "");
       setEndDate("");
@@ -95,7 +103,14 @@ export function AssignmentModal({
     }
     setEmployeeError(null);
     setShowDeleteConfirm(false);
-  }, [open, assignment, defaultEmployeeId, defaultProjectId, defaultStartDate]);
+  }, [
+    open,
+    assignment,
+    defaultEmployeeId,
+    defaultProjectId,
+    defaultStartDate,
+    defaultUnassigned,
+  ]);
 
   const createMutation = useMutation({
     mutationFn: createAssignment,

--- a/frontend/src/components/assignments/AssignmentModal.tsx
+++ b/frontend/src/components/assignments/AssignmentModal.tsx
@@ -70,7 +70,9 @@ export function AssignmentModal({
   useEffect(() => {
     if (!open) return;
     if (assignment) {
-      setEmployeeId(defaultEmployeeId ? String(defaultEmployeeId) : "");
+      // When editing, a null defaultEmployeeId means this is a placeholder
+      // assignment (no employee yet) — show the "Nieprzypisane" option.
+      setEmployeeId(defaultEmployeeId != null ? String(defaultEmployeeId) : "none");
       setProjectId(String(assignment.project_id));
       setStartDate(assignment.start_date);
       setEndDate(assignment.end_date);
@@ -128,7 +130,9 @@ export function AssignmentModal({
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const data = {
-      employee_id: Number(employeeId),
+      // "none" or empty => placeholder assignment (no employee).
+      employee_id:
+        employeeId && employeeId !== "none" ? Number(employeeId) : null,
       project_id: Number(projectId),
       start_date: startDate,
       end_date: endDate,

--- a/frontend/src/components/assignments/AssignmentModal.tsx
+++ b/frontend/src/components/assignments/AssignmentModal.tsx
@@ -28,6 +28,7 @@ export function AssignmentModal({
   const isEditing = !!assignment;
 
   const [employeeId, setEmployeeId] = useState("");
+  const [employeeError, setEmployeeError] = useState<string | null>(null);
   const [projectId, setProjectId] = useState("");
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
@@ -81,7 +82,9 @@ export function AssignmentModal({
       setNote(assignment.note ?? "");
       setIsTentative(assignment.is_tentative);
     } else {
-      setEmployeeId(defaultEmployeeId ? String(defaultEmployeeId) : "");
+      // Create mode: no preselected employee means "nothing selected" ("").
+      // Creating a placeholder requires explicitly picking the "none" option.
+      setEmployeeId(defaultEmployeeId != null ? String(defaultEmployeeId) : "");
       setProjectId(defaultProjectId ? String(defaultProjectId) : "");
       setStartDate(defaultStartDate ?? "");
       setEndDate("");
@@ -90,6 +93,7 @@ export function AssignmentModal({
       setNote("");
       setIsTentative(false);
     }
+    setEmployeeError(null);
     setShowDeleteConfirm(false);
   }, [open, assignment, defaultEmployeeId, defaultProjectId, defaultStartDate]);
 
@@ -129,10 +133,16 @@ export function AssignmentModal({
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    // The field is required: an empty selection is a validation error. Only the
+    // explicit "none" option ("Nieprzypisane") creates a placeholder assignment.
+    if (!employeeId) {
+      setEmployeeError(
+        "Wybierz pracownika lub opcję „Nieprzypisane (placeholder)”",
+      );
+      return;
+    }
     const data = {
-      // "none" or empty => placeholder assignment (no employee).
-      employee_id:
-        employeeId && employeeId !== "none" ? Number(employeeId) : null,
+      employee_id: employeeId === "none" ? null : Number(employeeId),
       project_id: Number(projectId),
       start_date: startDate,
       end_date: endDate,
@@ -165,10 +175,14 @@ export function AssignmentModal({
           <AssignmentFormEmployeeProject
             employeeId={employeeId}
             projectId={projectId}
-            onEmployeeChange={setEmployeeId}
+            onEmployeeChange={(value) => {
+              setEmployeeId(value);
+              setEmployeeError(null);
+            }}
             onProjectChange={setProjectId}
             employees={employees}
             projects={projects}
+            employeeError={employeeError}
           />
 
           <AssignmentFormDates

--- a/frontend/src/components/project-timeline/ProjectTimelineRow.tsx
+++ b/frontend/src/components/project-timeline/ProjectTimelineRow.tsx
@@ -80,7 +80,7 @@ export function ProjectTimelineRow({
     const adapted: TimelineAssignment = {
       id: assignment.id,
       project_id: project.id,
-      project_name: assignment.employee_name,
+      project_name: assignment.employee_name ?? "Nieprzypisane",
       project_color: project.color,
       start_date: assignment.start_date,
       end_date: assignment.end_date,
@@ -95,7 +95,9 @@ export function ProjectTimelineRow({
 
   const maxRows = bars.length > 0 ? Math.max(...bars.map((b) => b.row)) + 1 : 1;
   const barRowHeight = 32;
-  const rowHeight = Math.max(38, maxRows * barRowHeight + 6);
+  // 8px top offset (see bar `top` below) + 28px bar + 8px bottom padding, held
+  // constant regardless of how many bars stack: rowHeight = maxRows*32 + 12.
+  const rowHeight = Math.max(44, maxRows * barRowHeight + 12);
 
   const totalWidth = isWeekly ? allDays.length * DAY_WIDTH : months.length * MONTH_WIDTH;
 
@@ -175,7 +177,7 @@ export function ProjectTimelineRow({
             <div
               key={bar.adapted.id}
               className="absolute"
-              style={{ top: bar.row * barRowHeight + 2 }}
+              style={{ top: bar.row * barRowHeight + 8 }}
             >
               <TimelineBar
                 assignment={bar.adapted}
@@ -203,6 +205,7 @@ export function ProjectTimelineRow({
                 readOnly={readOnly}
                 showResizeLeft={resizeVis.showResizeLeft}
                 showResizeRight={resizeVis.showResizeRight}
+                isPlaceholder={bar.original.employee_id == null}
               />
             </div>
           );

--- a/frontend/src/components/timeline/Timeline.tsx
+++ b/frontend/src/components/timeline/Timeline.tsx
@@ -127,6 +127,7 @@ export function Timeline({ onNavigate }: TimelineProps = {}) {
   const [defaultEmployeeId, setDefaultEmployeeId] = useState<number | null>(
     null,
   );
+  const [defaultUnassigned, setDefaultUnassigned] = useState(false);
   const [defaultStartDate, setDefaultStartDate] = useState<string | null>(null);
   const [vacationModalOpen, setVacationModalOpen] = useState(false);
   const [selectedVacation, setSelectedVacation] = useState<VacationInfo | null>(
@@ -415,6 +416,9 @@ export function Timeline({ onNavigate }: TimelineProps = {}) {
   const handleEmptyClick = (employeeId: number | null, dateKey: string) => {
     setEditingAssignment(null);
     setDefaultEmployeeId(employeeId);
+    // Clicking in the placeholder row already expresses "unassigned" intent,
+    // so the modal preselects the "none" option there.
+    setDefaultUnassigned(employeeId === null);
     setDefaultStartDate(dateKey.length === 10 ? dateKey : `${dateKey}-01`);
     setModalOpen(true);
   };
@@ -696,6 +700,7 @@ export function Timeline({ onNavigate }: TimelineProps = {}) {
         }}
         assignment={editingAssignment}
         defaultEmployeeId={defaultEmployeeId}
+        defaultUnassigned={defaultUnassigned}
         defaultStartDate={defaultStartDate}
       />
     </div>

--- a/frontend/src/components/timeline/Timeline.tsx
+++ b/frontend/src/components/timeline/Timeline.tsx
@@ -40,7 +40,10 @@ import { triggerVacationSync } from "@/api/settings";
 import { VacationDialog } from "./VacationDialog";
 import { TimelineEmptyState } from "./TimelineEmptyState";
 import type { VacationRange } from "@/types/timeline";
-import { TIMELINE_LEFT_PANEL_WIDTH } from "@/lib/constants";
+import {
+  TIMELINE_LEFT_PANEL_WIDTH,
+  PLACEHOLDER_EMPLOYEE_ID,
+} from "@/lib/constants";
 import { TimelineBarDragPreview } from "./TimelineBarDragPreview";
 
 type TimelineProps = {
@@ -129,6 +132,9 @@ export function Timeline({ onNavigate }: TimelineProps = {}) {
   const [selectedVacation, setSelectedVacation] = useState<VacationInfo | null>(
     null,
   );
+  const [placeholderCollapsed, setPlaceholderCollapsed] = useState(false);
+
+  const placeholders = data?.placeholders ?? [];
 
   const [dragPreview, setDragPreview] = useState<{
     assignment: TimelineAssignment;
@@ -303,13 +309,22 @@ export function Timeline({ onNavigate }: TimelineProps = {}) {
       if (!dragData || !dropData) return;
       if (dragData.employeeId === dropData.employeeId) return;
 
+      // Dropping onto the synthetic placeholder row un-assigns the assignment.
+      const isPlaceholderTarget =
+        dropData.employeeId === PLACEHOLDER_EMPLOYEE_ID;
+      const newEmployeeId = isPlaceholderTarget ? null : dropData.employeeId;
+
       patchMutation.mutate(
         {
           id: dragData.assignment.id,
-          data: { employee_id: dropData.employeeId },
+          data: { employee_id: newEmployeeId },
         },
         {
           onSuccess: () => {
+            if (isPlaceholderTarget) {
+              toast.success("Assignment przeniesiony do nieprzypisanych");
+              return;
+            }
             const targetName =
               data?.employees.find((e) => e.id === dropData.employeeId)?.name ??
               "innego pracownika";
@@ -334,11 +349,16 @@ export function Timeline({ onNavigate }: TimelineProps = {}) {
     (assignmentId: number, edge: "left" | "right", deltaPx: number) => {
       if (!data) return;
 
-      // Find the assignment in data
+      // Find the assignment in data (employee rows or the placeholder row)
       let assignment: TimelineAssignment | undefined;
       for (const emp of data.employees) {
         assignment = emp.assignments.find((a) => a.id === assignmentId);
         if (assignment) break;
+      }
+      if (!assignment) {
+        assignment = (data.placeholders ?? []).find(
+          (a) => a.id === assignmentId,
+        );
       }
       if (!assignment) return;
 
@@ -382,16 +402,22 @@ export function Timeline({ onNavigate }: TimelineProps = {}) {
 
   const handleAssignmentClick = (
     assignment: TimelineAssignment,
-    employeeId: number,
+    employeeId: number | null,
   ) => {
     setEditingAssignment(assignment);
-    setDefaultEmployeeId(employeeId);
+    // null (placeholder row) => modal shows the assignment as unassigned.
+    setDefaultEmployeeId(
+      employeeId === PLACEHOLDER_EMPLOYEE_ID ? null : employeeId,
+    );
     setModalOpen(true);
   };
 
   const handleEmptyClick = (employeeId: number, dateKey: string) => {
     setEditingAssignment(null);
-    setDefaultEmployeeId(employeeId);
+    // Clicking an empty cell in the placeholder row creates a new placeholder.
+    setDefaultEmployeeId(
+      employeeId === PLACEHOLDER_EMPLOYEE_ID ? null : employeeId,
+    );
     setDefaultStartDate(dateKey.length === 10 ? dateKey : `${dateKey}-01`);
     setModalOpen(true);
   };
@@ -548,6 +574,33 @@ export function Timeline({ onNavigate }: TimelineProps = {}) {
                     />
                   </div>
                 </div>
+                {placeholders.length > 0 && (
+                  <TimelineRow
+                    key="placeholder-row"
+                    employeeId={PLACEHOLDER_EMPLOYEE_ID}
+                    name="Nieprzypisane"
+                    team={null}
+                    assignments={placeholders}
+                    occupancy={{}}
+                    months={months}
+                    weeks={weeks}
+                    allDays={allDays}
+                    viewMode={viewMode}
+                    holidayMap={holidayMap}
+                    isPlaceholderRow
+                    collapsed={placeholderCollapsed}
+                    onToggleCollapse={() =>
+                      setPlaceholderCollapsed((v) => !v)
+                    }
+                    onAssignmentClick={(a) => handleAssignmentClick(a, null)}
+                    onVacationClick={handleVacationClick}
+                    onEmptyClick={handleEmptyClick}
+                    onResizeEnd={handleResizeEnd}
+                    onBarContextMenu={handleBarContextMenu}
+                    readOnly={isViewer}
+                    isOdd={false}
+                  />
+                )}
                 {displayedEmployees.map((emp, idx) => (
                   <TimelineRow
                     key={emp.id}

--- a/frontend/src/components/timeline/Timeline.tsx
+++ b/frontend/src/components/timeline/Timeline.tsx
@@ -400,24 +400,21 @@ export function Timeline({ onNavigate }: TimelineProps = {}) {
     [data, months, viewMode, patchMutation],
   );
 
+  // Convention: the placeholder row passes `null` as employeeId directly;
+  // employee rows pass their numeric id.
   const handleAssignmentClick = (
     assignment: TimelineAssignment,
     employeeId: number | null,
   ) => {
     setEditingAssignment(assignment);
     // null (placeholder row) => modal shows the assignment as unassigned.
-    setDefaultEmployeeId(
-      employeeId === PLACEHOLDER_EMPLOYEE_ID ? null : employeeId,
-    );
+    setDefaultEmployeeId(employeeId);
     setModalOpen(true);
   };
 
-  const handleEmptyClick = (employeeId: number, dateKey: string) => {
+  const handleEmptyClick = (employeeId: number | null, dateKey: string) => {
     setEditingAssignment(null);
-    // Clicking an empty cell in the placeholder row creates a new placeholder.
-    setDefaultEmployeeId(
-      employeeId === PLACEHOLDER_EMPLOYEE_ID ? null : employeeId,
-    );
+    setDefaultEmployeeId(employeeId);
     setDefaultStartDate(dateKey.length === 10 ? dateKey : `${dateKey}-01`);
     setModalOpen(true);
   };
@@ -594,7 +591,7 @@ export function Timeline({ onNavigate }: TimelineProps = {}) {
                     }
                     onAssignmentClick={(a) => handleAssignmentClick(a, null)}
                     onVacationClick={handleVacationClick}
-                    onEmptyClick={handleEmptyClick}
+                    onEmptyClick={(_, dateKey) => handleEmptyClick(null, dateKey)}
                     onResizeEnd={handleResizeEnd}
                     onBarContextMenu={handleBarContextMenu}
                     readOnly={isViewer}

--- a/frontend/src/components/timeline/TimelineBar.tsx
+++ b/frontend/src/components/timeline/TimelineBar.tsx
@@ -10,7 +10,7 @@ import {
 import { createPortal } from "react-dom";
 import { addDays, format, parseISO } from "date-fns";
 import { pl } from "date-fns/locale";
-import { CircleHelp, StickyNote } from "lucide-react";
+import { CircleHelp, StickyNote, UserPlus } from "lucide-react";
 import type { TimelineBarProps } from "@/types/timeline";
 import { getContrastTextClass } from "@/lib/utils";
 import { TIMELINE_LEFT_PANEL_WIDTH } from "@/lib/constants";
@@ -31,7 +31,12 @@ export function TimelineBar({
   showResizeDateTooltip = false,
   showResizeLeft = true,
   showResizeRight = true,
+  isPlaceholder = false,
 }: TimelineBarProps) {
+  // Placeholder bars look identical to normal (filled) bars — they are only
+  // distinguished by the UserPlus icon and by living in the "Nieprzypisane"
+  // section. The outlined style is reserved for tentative assignments.
+  const outlined = assignment.is_tentative;
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `assignment-${assignment.id}`,
     data: { assignment, employeeId, barWidth: width, showDailyHours },
@@ -164,7 +169,7 @@ export function TimelineBar({
         ? `${assignment.allocation_value}h/m (${assignment.daily_hours}h/d)`
         : `${assignment.allocation_value}h tot. (${assignment.daily_hours}h/d)`;
 
-  const textColorClass = assignment.is_tentative
+  const textColorClass = outlined
     ? ""
     : getContrastTextClass(assignment.project_color);
 
@@ -179,7 +184,7 @@ export function TimelineBar({
   }
   adjustedWidth = Math.max(adjustedWidth, 20);
 
-  const style: React.CSSProperties = assignment.is_tentative
+  const style: React.CSSProperties = outlined
     ? {
         left: adjustedLeft,
         width: adjustedWidth,
@@ -259,11 +264,14 @@ export function TimelineBar({
             position: "sticky",
             left: TIMELINE_LEFT_PANEL_WIDTH,
             top: 0,
-            backgroundColor: assignment.is_tentative
+            backgroundColor: outlined
               ? "var(--background)"
               : assignment.project_color,
           }}
         >
+          {isPlaceholder && (
+            <UserPlus size={12} className="shrink-0 opacity-75" />
+          )}
           <span className="min-w-0 flex-1 truncate">
             {showDailyHours
               ? `${assignment.project_name} · (${assignment.daily_hours}h/d)`

--- a/frontend/src/components/timeline/TimelineRow.tsx
+++ b/frontend/src/components/timeline/TimelineRow.tsx
@@ -5,9 +5,14 @@ import {
   differenceInCalendarDays,
   format,
 } from "date-fns";
+import { ChevronDown, ChevronRight, Users } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import type { TimelineRowProps, DateRange } from "@/types/timeline";
-import { LEAVE_TYPE_LABELS, getUtilColor } from "@/lib/constants";
+import {
+  LEAVE_TYPE_LABELS,
+  getUtilColor,
+  TIMELINE_LEFT_PANEL_WIDTH,
+} from "@/lib/constants";
 import {
   getDateFromMonthlyPixelPosition,
   computeBarPositionMonthly,
@@ -31,6 +36,9 @@ export function TimelineRow({
   allDays,
   viewMode,
   holidayMap,
+  isPlaceholderRow = false,
+  collapsed = false,
+  onToggleCollapse,
   onAssignmentClick,
   onVacationClick,
   onEmptyClick,
@@ -43,6 +51,8 @@ export function TimelineRow({
     id: `employee-${employeeId}`,
     data: { employeeId },
   });
+
+  const showBars = !isPlaceholderRow || !collapsed;
 
   const isWeekly = viewMode === "weekly";
 
@@ -89,7 +99,16 @@ export function TimelineRow({
     allBars.length > 0 ? Math.max(...allBars.map((b) => b.row)) + 1 : 1;
   const utilRowHeight = 18;
   const barRowHeight = 32;
-  const rowHeight = Math.max(38, maxRows * barRowHeight + 6 + utilRowHeight);
+  // Placeholder row has no per-period occupancy strip, so instead of the wide
+  // top offset used by employee rows it gets a symmetric 8px top/bottom padding
+  // (same as project rows): 8px top + 28px bar + 8px bottom = maxRows*32 + 12,
+  // constant regardless of how many bars stack.
+  const barTopBase = isPlaceholderRow ? 8 : utilRowHeight;
+  const rowHeight = isPlaceholderRow
+    ? collapsed
+      ? 44
+      : Math.max(44, maxRows * barRowHeight + 12)
+    : Math.max(38, maxRows * barRowHeight + 6 + utilRowHeight);
 
   const totalWidth = isWeekly
     ? allDays.length * DAY_WIDTH
@@ -137,29 +156,50 @@ export function TimelineRow({
         title: undefined as string | undefined,
       }));
 
-  const LEFT_PANEL_WIDTH = 250;
-
   return (
     <div
       className={`flex border-b ${isOdd ? "bg-muted/20" : ""} ${
         isOver ? "ring-2 ring-inset ring-primary/50" : ""
       }`}
-      style={{ minWidth: LEFT_PANEL_WIDTH + totalWidth }}
+      style={{ minWidth: TIMELINE_LEFT_PANEL_WIDTH + totalWidth }}
     >
       {/* Sticky left panel */}
-      <div
-        className="sticky left-0 z-10 flex shrink-0 items-center gap-2 border-r bg-background px-3 py-2"
-        style={{ width: LEFT_PANEL_WIDTH, minHeight: rowHeight }}
-      >
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-medium">{name}</div>
-          {team && (
-            <Badge variant="secondary" className="mt-0.5 text-[10px]">
-              {team}
-            </Badge>
+      {isPlaceholderRow ? (
+        <button
+          type="button"
+          onClick={onToggleCollapse}
+          aria-expanded={!collapsed}
+          className="sticky left-0 z-10 flex shrink-0 items-center gap-2 border-r bg-background px-3 py-2 text-left hover:bg-muted/50"
+          style={{ width: TIMELINE_LEFT_PANEL_WIDTH, minHeight: rowHeight }}
+        >
+          {collapsed ? (
+            <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
           )}
+          <Users className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 truncate text-sm font-medium">
+            {name}
+          </span>
+          <Badge variant="secondary" className="shrink-0 text-[10px]">
+            {assignments.length}
+          </Badge>
+        </button>
+      ) : (
+        <div
+          className="sticky left-0 z-10 flex shrink-0 items-center gap-2 border-r bg-background px-3 py-2"
+          style={{ width: TIMELINE_LEFT_PANEL_WIDTH, minHeight: rowHeight }}
+        >
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-medium">{name}</div>
+            {team && (
+              <Badge variant="secondary" className="mt-0.5 text-[10px]">
+                {team}
+              </Badge>
+            )}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Timeline area */}
       <div
@@ -170,7 +210,8 @@ export function TimelineRow({
           minHeight: rowHeight,
         }}
       >
-        {/* Per-period occupancy indicators */}
+        {/* Per-period occupancy indicators (not shown for the placeholder row) */}
+        {!isPlaceholderRow && (
         <div
           className="absolute top-0 left-0 z-1 flex bg-transparent"
           style={{ height: utilRowHeight }}
@@ -187,6 +228,7 @@ export function TimelineRow({
             </div>
           ))}
         </div>
+        )}
 
         {/* Separators */}
         {separatorColumns.map((col) => (
@@ -222,7 +264,8 @@ export function TimelineRow({
         ))}
 
         {/* Assignment bars */}
-        {bars.map((bar) => {
+        {showBars &&
+          bars.map((bar) => {
           const resizeVis = getResizeHandleVisibility(
             bar.assignment,
             isWeekly,
@@ -234,7 +277,7 @@ export function TimelineRow({
               key={bar.assignment.id}
               className="absolute"
               style={{
-                top: bar.row * barRowHeight + 2 + utilRowHeight,
+                top: bar.row * barRowHeight + 2 + barTopBase,
               }}
             >
               <TimelineBar
@@ -272,13 +315,15 @@ export function TimelineRow({
                 readOnly={readOnly}
                 showResizeLeft={resizeVis.showResizeLeft}
                 showResizeRight={resizeVis.showResizeRight}
+                isPlaceholder={isPlaceholderRow}
               />
             </div>
           );
         })}
 
         {/* Vacation bars */}
-        {vacationBars.map((vbar, i) => {
+        {showBars &&
+          vacationBars.map((vbar, i) => {
           const label =
             LEAVE_TYPE_LABELS[vbar.vacation.leave_type] ??
             vbar.vacation.leave_type;
@@ -289,7 +334,7 @@ export function TimelineRow({
               tabIndex={0}
               className="absolute flex cursor-pointer items-center overflow-hidden rounded bg-slate-400/80 text-xs text-white shadow-sm select-none dark:bg-slate-500/80"
               style={{
-                top: vbar.row * barRowHeight + 2 + utilRowHeight,
+                top: vbar.row * barRowHeight + 2 + barTopBase,
                 left: vbar.left,
                 width: Math.max(vbar.width, 20),
                 height: 28,

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -12,3 +12,10 @@ export function getUtilColor(pct: number): string {
 }
 
 export const TIMELINE_LEFT_PANEL_WIDTH = 250;
+
+/**
+ * Sentinel employee id used by the synthetic "Nieprzypisane" (placeholder) row
+ * in the timeline. Dropping an assignment onto this row un-assigns it (sets
+ * employee_id to null); dragging a placeholder bar onto a real row assigns it.
+ */
+export const PLACEHOLDER_EMPLOYEE_ID = -1;

--- a/frontend/src/types/assignment.ts
+++ b/frontend/src/types/assignment.ts
@@ -48,13 +48,16 @@ export interface VacationSyncStatus {
 
 export interface TimelineData {
   employees: TimelineEmployee[];
+  /** Assignments not yet allocated to any employee (employee_id IS NULL). */
+  placeholders?: TimelineAssignment[];
   holidays: HolidayInfo[];
   working_days_per_month: Record<string, number>;
   vacation_sync_status?: VacationSyncStatus;
 }
 
 export interface AssignmentCreateData {
-  employee_id: number;
+  /** null => placeholder assignment (not yet allocated to a person). */
+  employee_id: number | null;
   project_id: number;
   start_date: string;
   end_date: string;

--- a/frontend/src/types/assignment.ts
+++ b/frontend/src/types/assignment.ts
@@ -74,6 +74,8 @@ export interface AssignmentModalProps {
   defaultEmployeeId?: number | null;
   defaultProjectId?: number | null;
   defaultStartDate?: string | null;
+  /** Preselect "Nieprzypisane" in create mode (e.g. click in the placeholder row). */
+  defaultUnassigned?: boolean;
 }
 
 export interface AssignmentEmployeeOption {

--- a/frontend/src/types/assignment.ts
+++ b/frontend/src/types/assignment.ts
@@ -95,6 +95,8 @@ export interface AssignmentFormEmployeeProjectProps {
   onProjectChange: (value: string) => void;
   employees: AssignmentEmployeeOption[];
   projects: AssignmentProjectOption[];
+  /** Validation error for the employee field (required in create mode). */
+  employeeError?: string | null;
 }
 
 export interface AssignmentFormDatesProps {

--- a/frontend/src/types/project-timeline.ts
+++ b/frontend/src/types/project-timeline.ts
@@ -2,8 +2,9 @@ import type { HolidayInfo } from "./assignment";
 
 export interface ProjectTimelineAssignment {
   id: number;
-  employee_id: number;
-  employee_name: string;
+  /** null => placeholder assignment (not yet allocated to a person). */
+  employee_id: number | null;
+  employee_name: string | null;
   employee_team: string | null;
   start_date: string;
   end_date: string;

--- a/frontend/src/types/timeline.ts
+++ b/frontend/src/types/timeline.ts
@@ -89,6 +89,12 @@ export interface TimelineRowProps {
   weeks: WeekInfo[];
   allDays: DayInfo[];
   viewMode: ViewMode;
+  /** Renders this as the synthetic "Nieprzypisane" (placeholder) row. */
+  isPlaceholderRow?: boolean;
+  /** Whether the placeholder row is collapsed (bars hidden). */
+  collapsed?: boolean;
+  /** Toggle handler shown in the placeholder row's left panel. */
+  onToggleCollapse?: () => void;
   onAssignmentClick: (assignment: TimelineAssignment) => void;
   onVacationClick: (vacation: VacationInfo) => void;
   onEmptyClick: (employeeId: number, dateKey: string) => void;
@@ -135,6 +141,8 @@ export interface TimelineBarProps {
   showResizeDateTooltip?: boolean;
   showResizeLeft?: boolean;
   showResizeRight?: boolean;
+  /** Render as an unassigned placeholder bar (dashed outline). */
+  isPlaceholder?: boolean;
 }
 
 export interface DaySummary {


### PR DESCRIPTION
## Summary

Adds **placeholder assignments** — planned work on a project that is not yet allocated to a specific person. A placeholder is an assignment with a `NULL` `employee_id`; the project and all other parameters (dates, allocation, note) are preserved. This lets planners record "this project needs someone for the Python part" before knowing who, and see that unallocated work in one place.

## ⚠️ Note for the reviewer — branch dependency

**This branch is stacked on `fix/ui-copy`, and this PR targets `fix/ui-copy` (not `main`).**

- The feature genuinely depends on code that lives in `fix/ui-copy` but not yet in `main`: several files edited here (`Timeline.tsx`, `TimelineRow.tsx`, `constants.ts`, `calendar.py`, `project_timeline.py`, `ProjectTimeline.tsx`) were also modified by commits on `fix/ui-copy` (unified filters / UI-copy work). Branching off `main` instead would have caused merge conflicts on those shared files.
- Because the base is `fix/ui-copy`, the diff here shows **only** the placeholder changes.
- **Merge order matters:** merge `fix/ui-copy` first, then this. If for any reason you review/merge out of order, be aware that this branch contains `fix/ui-copy`'s commits as ancestors — merging this straight into `main` before `fix/ui-copy` would bring those commits along too (Git de-duplicates them once `fix/ui-copy` lands, so no conflict results, but the intent is to keep them separate).

## Changes

### Backend
- `Assignment.employee_id` is now nullable (+ Alembic migration dropping `NOT NULL`).
- `AssignmentCreate`/`AssignmentResponse` accept an optional `employee_id`. Create validates the employee only when present. `PATCH` supports explicit un-assign (`employee_id: null`) to turn an assignment back into a placeholder. Duplicate handles placeholders.
- Timeline endpoint returns a separate `placeholders` list; project-timeline includes `NULL`-employee assignments (and no longer crashes on a missing employee).

### Frontend
- **Employee calendar:** a dedicated collapsible "Nieprzypisane" row pinned at the top, aligned to the time axis, with a count badge.
- Drag a placeholder bar onto an employee row to assign it; drag an assignment onto the placeholder row to un-assign it (reuses the existing drag-to-move machinery).
- `AssignmentModal` allows leaving the employee empty to create a placeholder.
- **Project calendar:** placeholders render inline per project, labelled "Nieprzypisane".
- Placeholder bars look like normal (filled) assignments plus a `UserPlus` icon, so the tentative (outlined) styling stays distinct.
- Consistent vertical padding across employee / project / placeholder rows; left-panel width unified to the shared `TIMELINE_LEFT_PANEL_WIDTH` constant.

## Verification
- `tsc --noEmit` — clean.
- Backend `pytest` — 55 passed.
- Frontend lint — no new errors (only pre-existing ones).
- Migration applied to the dev DB and verified: `assignments.employee_id` is now nullable, `project_id` stays `NOT NULL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
