### PR TITLE
fix: backfill missing FK indexes and reset unassigned intent in assignment modal

### DIFF
--- a/backend/alembic/versions/m3b4c5d6e7f8_backfill_fk_indexes_teams_technologies.py
+++ b/backend/alembic/versions/m3b4c5d6e7f8_backfill_fk_indexes_teams_technologies.py
@@ -1,0 +1,43 @@
+"""backfill_fk_indexes_teams_technologies
+
+Catch-up migration for two FK indexes that were added retroactively to the
+already-merged revision j0e1f2a3b4c5 instead of in a new revision. Databases
+that had applied j0e1f2a3b4c5 before that edit never received the indexes and
+never will, since Alembic considers the revision done.
+
+Both statements are idempotent: databases created from the edited
+j0e1f2a3b4c5 already have the indexes and are left untouched.
+
+Revision ID: m3b4c5d6e7f8
+Revises: l2a3b4c5d6e7
+Create Date: 2026-08-06 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'm3b4c5d6e7f8'
+down_revision: Union[str, Sequence[str], None] = 'l2a3b4c5d6e7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_employees_team_id "
+        "ON employees (team_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_employee_technologies_technology_id "
+        "ON employee_technologies (technology_id)"
+    )
+
+
+def downgrade() -> None:
+    # Left as a no-op on purpose: j0e1f2a3b4c5 also creates these indexes, so
+    # dropping them here would leave databases created from that revision
+    # without indexes their own migration is responsible for.
+    pass

--- a/frontend/src/components/timeline/Timeline.tsx
+++ b/frontend/src/components/timeline/Timeline.tsx
@@ -431,6 +431,9 @@ export function Timeline({ onNavigate }: TimelineProps = {}) {
   const handleNewAssignment = () => {
     setEditingAssignment(null);
     setDefaultEmployeeId(null);
+    // No placeholder intent here: reset it so a prior click in the placeholder
+    // row does not leak "Nieprzypisane" into a plain new assignment.
+    setDefaultUnassigned(false);
     setDefaultStartDate(null);
     setModalOpen(true);
   };


### PR DESCRIPTION
Two independent follow-up fixes to recently merged work, one commit each.

## 1. Backfill FK indexes missed by a retroactive migration edit

`3bbaeb7` (PR #71) added `index=True` on `employees.team_id` and `employee_technologies.technology_id`, and wrote the matching `create_index` calls **into the already-merged revision `j0e1f2a3b4c5`** rather than into a new revision.

Alembic considers that revision applied, so any database that upgraded before the edit never got the indexes and never will. Confirmed on a local database: both indexes absent while `alembic_version` sat past `j0e1f2a3b4c5`, and `alembic upgrade head` was a no-op.

New revision `m3b4c5d6e7f8` backfills them. It has to serve two populations, so both statements are `CREATE INDEX IF NOT EXISTS`:

- databases from **before** the edit — indexes get created here
- databases from **after** the edit — `j0e1f2a3b4c5` already created them, so this is a no-op

`j0e1f2a3b4c5` itself is left alone; reverting a merged migration would be one more edit to history, and the duplicate definition is harmless under `IF NOT EXISTS`.

`downgrade()` is a deliberate no-op, documented inline: dropping the indexes would strip them from databases whose own earlier migration is responsible for creating them.

Verified both directions on a local database:
- indexes present → `upgrade head` succeeds, changes nothing
- simulated pre-fix state (indexes dropped, `alembic_version` reset to `l2a3b4c5d6e7`) → `upgrade head` creates both

## 2. Reset unassigned intent when opening the new-assignment modal

`81dfab8` (PR #75) added the `defaultUnassigned` prop so that clicking an empty cell in the placeholder row preselects "Nieprzypisane". `handleNewAssignment` sets `defaultEmployeeId` and `defaultStartDate` but never resets that flag, so it leaks across modal openings.

Repro: click an empty cell in the placeholder row → cancel → press the new-assignment button. The modal comes up with "Nieprzypisane" preselected for what should be a plain new assignment.

That reopens the silent path to accidentally creating a placeholder — exactly what the explicit employee-field validation in `ec7bc62` was added to close.

All three modal entry points are now consistent: `handleEmptyClick` sets the flag from the row, `handleNewAssignment` clears it, and `handleAssignmentClick` opens edit mode, where the modal never reads the flag (it derives the value from `defaultEmployeeId != null`).

`npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)