### PR TITLE
feat: rework project lifecycle into archive vs permanent delete (#73, part 1/2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,13 @@ cd frontend && npm run test
 - CSS: exclusively Tailwind utility classes + shadcn/ui
 - Naming: PascalCase components, camelCase functions, SCREAMING_SNAKE constants
 
+### UI Copy (Polish)
+
+- **Never use an em dash (`—`) inside a sentence.** It reads as machine-written. Use a comma, a full stop, or a colon introducing a bulleted list instead.
+- The `—` glyph is still correct where it is a symbol rather than punctuation: empty-value placeholders in tables (`{value || "—"}`) and neutral select options such as `— Brak —`. Do not rewrite those.
+- In confirmation dialogs, split the consequences into a bulleted list rather than one long sentence, and bold the irreversible part.
+- Name the consequence, not just the action: say what happens to existing data, not only that something will be archived or deleted.
+
 ## Key Business Rules
 
 - 1 FTE = 100% = 8h/day x working days/month

--- a/backend/alembic/versions/m3b4c5d6e7f8_backfill_fk_indexes_teams_technologies.py
+++ b/backend/alembic/versions/m3b4c5d6e7f8_backfill_fk_indexes_teams_technologies.py
@@ -1,0 +1,43 @@
+"""backfill_fk_indexes_teams_technologies
+
+Catch-up migration for two FK indexes that were added retroactively to the
+already-merged revision j0e1f2a3b4c5 instead of in a new revision. Databases
+that had applied j0e1f2a3b4c5 before that edit never received the indexes and
+never will, since Alembic considers the revision done.
+
+Both statements are idempotent: databases created from the edited
+j0e1f2a3b4c5 already have the indexes and are left untouched.
+
+Revision ID: m3b4c5d6e7f8
+Revises: l2a3b4c5d6e7
+Create Date: 2026-08-06 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'm3b4c5d6e7f8'
+down_revision: Union[str, Sequence[str], None] = 'l2a3b4c5d6e7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_employees_team_id "
+        "ON employees (team_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_employee_technologies_technology_id "
+        "ON employee_technologies (technology_id)"
+    )
+
+
+def downgrade() -> None:
+    # Left as a no-op on purpose: j0e1f2a3b4c5 also creates these indexes, so
+    # dropping them here would leave databases created from that revision
+    # without indexes their own migration is responsible for.
+    pass

--- a/backend/alembic/versions/n4c5d6e7f8a9_project_lifecycle_archive_vs_delete.py
+++ b/backend/alembic/versions/n4c5d6e7f8a9_project_lifecycle_archive_vs_delete.py
@@ -1,0 +1,54 @@
+"""project_lifecycle_archive_vs_delete
+
+Rework the project lifecycle into two distinct operations: archive (reversible
+wind-down) and delete (permanent). Soft delete is removed — deletion is now a
+hard delete of the project and all of its assignments — so `is_deleted` becomes
+obsolete and is dropped.
+
+Existing soft-deleted projects are **converted to archived**, not hard-deleted.
+They are invisible in the UI today, yet their assignments still render in the
+employee timeline (that query never filtered on project state), so deleting
+them would silently erase historical occupancy that users can currently see.
+Archiving matches the behaviour they already have and surfaces them in the
+project list, where they can be reviewed and deleted deliberately.
+
+Revision ID: n4c5d6e7f8a9
+Revises: m3b4c5d6e7f8
+Create Date: 2026-08-06 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'n4c5d6e7f8a9'
+down_revision: Union[str, Sequence[str], None] = 'm3b4c5d6e7f8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Preserve soft-deleted projects as archived instead of dropping them.
+    op.execute(
+        "UPDATE projects SET is_archived = true WHERE is_deleted = true"
+    )
+    op.drop_column("projects", "is_deleted")
+
+
+def downgrade() -> None:
+    # The column comes back, but which archived projects were once soft-deleted
+    # is not recoverable — that distinction is gone for good. Everything is
+    # restored as not deleted, which keeps every project reachable rather than
+    # resurrecting rows into a hidden state.
+    op.add_column(
+        "projects",
+        sa.Column(
+            "is_deleted",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )

--- a/backend/app/api/assignments.py
+++ b/backend/app/api/assignments.py
@@ -103,11 +103,7 @@ async def create_assignment(
             raise HTTPException(status_code=404, detail="Employee not found")
 
     # Validate project exists and is not archived
-    proj = await db.execute(
-        select(Project).where(
-            Project.id == body.project_id, Project.is_deleted == False
-        )
-    )
+    proj = await db.execute(select(Project).where(Project.id == body.project_id))
     project = proj.scalar_one_or_none()
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
@@ -160,11 +156,7 @@ async def update_assignment(
             assignment.employee_id = body.employee_id
 
     if body.project_id is not None:
-        proj = await db.execute(
-            select(Project).where(
-                Project.id == body.project_id, Project.is_deleted == False
-            )
-        )
+        proj = await db.execute(select(Project).where(Project.id == body.project_id))
         project = proj.scalar_one_or_none()
         if not project:
             raise HTTPException(status_code=404, detail="Project not found")
@@ -268,7 +260,8 @@ async def duplicate_assignment(
     if not assignment:
         raise HTTPException(status_code=404, detail="Assignment not found")
 
-    # Validate employee and project are not soft-deleted
+    # Duplicating creates a new assignment, so it is subject to the same guards
+    # as create: the employee must not be deleted and the project not archived.
     # (placeholder assignments have no employee, so skip the employee check)
     if assignment.employee_id is not None:
         emp = await db.execute(
@@ -280,12 +273,16 @@ async def duplicate_assignment(
             raise HTTPException(status_code=400, detail="Cannot duplicate: employee has been deleted")
 
     proj = await db.execute(
-        select(Project).where(
-            Project.id == assignment.project_id, Project.is_deleted == False
-        )
+        select(Project).where(Project.id == assignment.project_id)
     )
-    if not proj.scalar_one_or_none():
-        raise HTTPException(status_code=400, detail="Cannot duplicate: project has been deleted")
+    project = proj.scalar_one_or_none()
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+    if project.is_archived:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Nie można przypisać pracownika do zarchiwizowanego projektu",
+        )
 
     new_assignment = Assignment(
         employee_id=assignment.employee_id,

--- a/backend/app/api/project_timeline.py
+++ b/backend/app/api/project_timeline.py
@@ -27,8 +27,13 @@ async def get_project_timeline(
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(get_current_user),
 ):
-    """Return timeline data grouped by project."""
-    proj_query = select(Project).where(Project.is_deleted == False)
+    """Return timeline data grouped by project.
+
+    Archived projects are excluded so the project-grouped view stays focused on
+    live work; their assignments remain visible in the employee timeline, which
+    is what preserves historical occupancy.
+    """
+    proj_query = select(Project).where(Project.is_archived == False)
     if search and search.strip():
         proj_query = proj_query.where(Project.name.ilike(f"%{search.strip()}%"))
     proj_query = proj_query.order_by(Project.name)

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import date
 from typing import Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -13,6 +12,11 @@ from app.models.assignment import Assignment
 from app.models.project import Project
 from app.models.user import User
 from app.schemas.project import ProjectCreate, ProjectResponse, ProjectUpdate
+from app.services.lifecycle_service import (
+    count_assignments,
+    delete_assignments,
+    wind_down_assignments,
+)
 
 router = APIRouter(prefix="/api/projects", tags=["projects"])
 
@@ -20,14 +24,11 @@ router = APIRouter(prefix="/api/projects", tags=["projects"])
 @router.get("", response_model=list[ProjectResponse])
 async def list_projects(
     search: Optional[str] = Query(None),
-    include_deleted: bool = Query(False),
     project_status: Literal["active", "archived", "all"] = Query("active", alias="status"),
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(get_current_user),
 ):
     query = select(Project)
-    if not include_deleted:
-        query = query.where(Project.is_deleted == False)
     if project_status == "active":
         query = query.where(Project.is_archived == False)
     elif project_status == "archived":
@@ -105,42 +106,34 @@ async def delete_project(
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(require_admin),
 ):
+    """Permanently delete a project together with every one of its assignments.
+
+    Irreversible, and it drops past, ongoing and future assignments alike.
+    Archiving is the reversible alternative: it winds the project down while
+    preserving history.
+    """
     result = await db.execute(select(Project).where(Project.id == project_id))
     project = result.scalar_one_or_none()
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
 
-    # Check for active assignments
-    today = date.today()
-    active_query = select(Assignment).where(
-        Assignment.project_id == project_id,
-        Assignment.end_date >= today,
-    )
-    active_result = await db.execute(active_query)
-    active_assignments = active_result.scalars().all()
+    assignment_filter = Assignment.project_id == project_id
+    assignments_count = await count_assignments(db, assignment_filter)
 
-    if active_assignments and not confirm:
+    if assignments_count and not confirm:
         return {
-            "has_active_assignments": True,
-            "active_assignments_count": len(active_assignments),
-            "message": "Project has active assignments. Pass ?confirm=true to proceed.",
+            "has_assignments": True,
+            "assignments_count": assignments_count,
+            "message": (
+                "Project has assignments that will be permanently deleted. "
+                "Pass ?confirm=true to proceed."
+            ),
         }
 
-    # Soft delete project
-    project.is_deleted = True
-
-    # Handle assignments like employee deletion:
-    # - Future assignments: remove
-    # - Ongoing assignments: trim end date to today
-    # - Historical assignments: preserve
-    for a in active_assignments:
-        if a.start_date >= today:
-            await db.delete(a)
-        else:
-            a.end_date = today
-
+    deleted_assignments = await delete_assignments(db, assignment_filter)
+    await db.delete(project)
     await db.commit()
-    return {"deleted": True}
+    return {"deleted": True, "deleted_assignments": deleted_assignments}
 
 
 @router.post("/{project_id}/archive", response_model=ProjectResponse)
@@ -149,14 +142,20 @@ async def archive_project(
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(require_editor),
 ):
+    """Archive a project and wind down its assignments.
+
+    Past assignments are preserved, ongoing ones are trimmed to end today, and
+    future ones are deleted. The project stays in the database and its history
+    remains visible in the employee timeline.
+    """
     result = await db.execute(select(Project).where(Project.id == project_id))
     project = result.scalar_one_or_none()
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
-    if project.is_deleted:
-        raise HTTPException(status_code=400, detail="Cannot archive a deleted project")
 
     project.is_archived = True
+    await wind_down_assignments(db, Assignment.project_id == project_id)
+
     await db.commit()
     await db.refresh(project)
     return project
@@ -168,13 +167,15 @@ async def unarchive_project(
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(require_editor),
 ):
+    """Re-enable an archived project for new assignments.
+
+    Does not restore assignments that archiving trimmed or deleted — archiving
+    is a wind-down, not a freeze.
+    """
     result = await db.execute(select(Project).where(Project.id == project_id))
     project = result.scalar_one_or_none()
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
-
-    if project.is_deleted:
-        raise HTTPException(status_code=400, detail="Cannot unarchive a deleted project")
 
     project.is_archived = False
     await db.commit()

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -12,6 +12,5 @@ class Project(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
     color: Mapped[str] = mapped_column(String(7), nullable=False)
-    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
     is_archived: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -37,7 +37,6 @@ class ProjectResponse(BaseModel):
     id: int
     name: str
     color: str
-    is_deleted: bool
     is_archived: bool
     created_at: datetime
 

--- a/backend/app/services/lifecycle_service.py
+++ b/backend/app/services/lifecycle_service.py
@@ -1,0 +1,107 @@
+"""Shared lifecycle operations for archivable resources (projects, employees).
+
+Archiving is a reversible *wind-down*, not a freeze: it stops new work and
+closes out work in flight, while leaving history intact. Deleting is permanent
+and takes every assignment with it.
+
+Both projects and employees follow identical rules, so the logic lives here
+rather than in either API module.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from enum import Enum
+
+from sqlalchemy import ColumnElement, delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.assignment import Assignment
+
+
+class WindDownAction(str, Enum):
+    """What archiving does to a single assignment."""
+
+    KEEP = "keep"
+    TRIM = "trim"
+    DELETE = "delete"
+
+
+@dataclass(frozen=True)
+class WindDownResult:
+    """How many assignments each wind-down branch touched."""
+
+    kept: int
+    trimmed: int
+    deleted: int
+
+
+def classify_for_wind_down(
+    start_date: date, end_date: date, today: date
+) -> WindDownAction:
+    """Decide what archiving does to an assignment, relative to `today`.
+
+    - **past** (`end_date < today`) — KEEP, so historical occupancy survives
+    - **ongoing** (`start_date <= today <= end_date`) — TRIM to end today
+    - **future** (`start_date > today`) — DELETE
+
+    Boundary rules are deliberate: an assignment starting today is ongoing and
+    gets trimmed to a single day rather than deleted, and one already ending
+    today is ongoing but needs no change, so it reports KEEP.
+    """
+    if end_date < today:
+        return WindDownAction.KEEP
+    if start_date > today:
+        return WindDownAction.DELETE
+    if end_date == today:
+        return WindDownAction.KEEP
+    return WindDownAction.TRIM
+
+
+async def wind_down_assignments(
+    db: AsyncSession,
+    condition: ColumnElement[bool],
+    today: date | None = None,
+) -> WindDownResult:
+    """Apply the archive wind-down to every assignment matching `condition`.
+
+    See `classify_for_wind_down` for the rules. Does not commit — the caller
+    owns the transaction.
+    """
+    today = today or date.today()
+
+    result = await db.execute(select(Assignment).where(condition))
+    kept = trimmed = deleted = 0
+
+    for assignment in result.scalars().all():
+        action = classify_for_wind_down(
+            assignment.start_date, assignment.end_date, today
+        )
+        if action is WindDownAction.DELETE:
+            await db.delete(assignment)
+            deleted += 1
+        elif action is WindDownAction.TRIM:
+            assignment.end_date = today
+            trimmed += 1
+        else:
+            kept += 1
+
+    return WindDownResult(kept=kept, trimmed=trimmed, deleted=deleted)
+
+
+async def count_assignments(db: AsyncSession, condition: ColumnElement[bool]) -> int:
+    """Count assignments matching `condition`."""
+    result = await db.execute(
+        select(func.count()).select_from(Assignment).where(condition)
+    )
+    return result.scalar_one()
+
+
+async def delete_assignments(db: AsyncSession, condition: ColumnElement[bool]) -> int:
+    """Hard-delete every assignment matching `condition`, returning the count.
+
+    Used by permanent deletion, which drops past, ongoing and future
+    assignments alike. Does not commit — the caller owns the transaction.
+    """
+    result = await db.execute(delete(Assignment).where(condition))
+    return result.rowcount or 0

--- a/backend/tests/test_lifecycle_wind_down.py
+++ b/backend/tests/test_lifecycle_wind_down.py
@@ -1,0 +1,86 @@
+"""Tests for the archive wind-down classification rules.
+
+The rules are shared by project and employee archiving, and the boundary cases
+(assignments starting or ending exactly today) are the ones most likely to
+regress, so they are pinned explicitly.
+"""
+
+from datetime import date
+
+from app.services.lifecycle_service import WindDownAction, classify_for_wind_down
+
+TODAY = date(2026, 7, 18)
+
+
+def classify(start: date, end: date) -> WindDownAction:
+    return classify_for_wind_down(start, end, TODAY)
+
+
+class TestPastAssignments:
+    def test_finished_before_today_is_kept(self):
+        assert (
+            classify(date(2026, 6, 1), date(2026, 7, 10)) is WindDownAction.KEEP
+        )
+
+    def test_ended_yesterday_is_kept(self):
+        assert (
+            classify(date(2026, 6, 1), date(2026, 7, 17)) is WindDownAction.KEEP
+        )
+
+    def test_long_finished_is_kept(self):
+        assert (
+            classify(date(2020, 1, 1), date(2020, 12, 31)) is WindDownAction.KEEP
+        )
+
+
+class TestOngoingAssignments:
+    def test_spanning_today_is_trimmed(self):
+        assert (
+            classify(date(2026, 7, 1), date(2026, 8, 31)) is WindDownAction.TRIM
+        )
+
+    def test_starting_today_is_ongoing_not_future(self):
+        # Trimmed to a single day rather than deleted.
+        assert (
+            classify(TODAY, date(2026, 9, 30)) is WindDownAction.TRIM
+        )
+
+    def test_ending_today_needs_no_change(self):
+        assert classify(date(2026, 7, 1), TODAY) is WindDownAction.KEEP
+
+    def test_single_day_today_needs_no_change(self):
+        assert classify(TODAY, TODAY) is WindDownAction.KEEP
+
+
+class TestFutureAssignments:
+    def test_starting_tomorrow_is_deleted(self):
+        assert (
+            classify(date(2026, 7, 19), date(2026, 8, 31))
+            is WindDownAction.DELETE
+        )
+
+    def test_far_future_is_deleted(self):
+        assert (
+            classify(date(2026, 8, 1), date(2026, 9, 30))
+            is WindDownAction.DELETE
+        )
+
+
+class TestIssueExample:
+    """The worked example from issue #73, with today = 2026-07-18."""
+
+    def test_finished_kept(self):
+        assert (
+            classify(date(2026, 6, 1), date(2026, 7, 10)) is WindDownAction.KEEP
+        )
+
+    def test_ongoing_trimmed(self):
+        assert (
+            classify(date(2026, 7, 1), date(2026, 8, 31)) is WindDownAction.TRIM
+        )
+
+    def test_future_deleted(self):
+        assert (
+            classify(date(2026, 8, 1), date(2026, 9, 30))
+            is WindDownAction.DELETE
+        )

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -46,14 +46,38 @@ On successful deletion: `{"deleted": true}` (200).
 ## Projects
 
 ```
-GET    /api/projects                        # List projects (200)
+GET    /api/projects                        # List projects (200, ?status=active|archived|all, default active)
 GET    /api/projects/timeline               # Timeline grouped by project (200, see below)
 POST   /api/projects                        # Create project, unique name (201)
 PATCH  /api/projects/{id}                   # Update project (200)
-DELETE /api/projects/{id}                   # Delete with cascade (200, see below)
+POST   /api/projects/{id}/archive           # Archive + wind down assignments (200, see below)
+POST   /api/projects/{id}/unarchive         # Re-enable for new assignments (200)
+DELETE /api/projects/{id}                   # Permanent delete with all assignments (200, see below)
 ```
 
-**Delete behavior:** Same two-step pattern as employees — returns active assignment info if `?confirm=true` is not passed.
+A project is either **active**, **archived**, or gone. There is no soft-deleted state.
+
+**Archive** is a reversible wind-down. Every assignment on the project is classified relative to today:
+
+| Category | Condition | Action |
+|---|---|---|
+| Past | `end_date < today` | kept untouched — historical occupancy is preserved |
+| Ongoing | `start_date <= today <= end_date` | `end_date` trimmed to today |
+| Future | `start_date > today` | deleted |
+
+Boundary rules: an assignment with `start_date == today` is *ongoing* (trimmed to a single day), not future; one with `end_date == today` is ongoing and needs no change.
+
+Archived projects are hidden from `GET /api/projects/timeline` but their assignments still appear in `GET /api/assignments/timeline`, so per-person history stays intact. Creating or patching an assignment onto an archived project returns 409, as does duplicating one.
+
+**Unarchive** re-enables the project for new assignments. It does **not** restore assignments that archiving trimmed or deleted.
+
+**Delete** is permanent: the project row and **all** of its assignments (past, ongoing and future) are removed. Two-step confirmation — without `?confirm=true`, a project that has any assignments returns them for confirmation instead of deleting:
+
+```json
+{"has_assignments": true, "assignments_count": 12, "message": "..."}
+```
+
+With `?confirm=true` (or when the project has no assignments): `{"deleted": true, "deleted_assignments": 12}`.
 
 ## Assignments
 

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -36,7 +36,7 @@
 | id | Integer | PK |
 | name | String | unique, not null |
 | color | String(7) | not null (hex color) |
-| is_deleted | Boolean | default false (soft delete) |
+| is_archived | Boolean | default false (wind-down state) |
 | created_at | DateTime | auto |
 
 ### Assignment
@@ -127,10 +127,16 @@ AppSettings (standalone — stores Calamari config etc.)
 - Vacation days reduce net available hours in occupancy calculations
 - Percentage allocations skip vacation days entirely; hours-based commitments stay fixed, so vacations can push occupancy above 100%
 
-### Deletion Rules
+### Lifecycle Rules
 
 | Entity | Behavior |
 |---|---|
 | **Employee** | Soft delete. Warning if active assignments exist. Future assignments removed, historical archived. |
-| **Project** | Soft delete. Cascade deletes all linked assignments (after confirmation). |
+| **Project** | Archive (reversible wind-down) or delete (permanent, takes all assignments). No soft-delete state. |
 | **Assignment** | Hard delete. Supports split and duplicate operations. |
+
+**Project archive vs delete.** Archiving winds a project down: past assignments are kept, ongoing ones are trimmed to end today, future ones are deleted, and no new assignments can be added (409). The project disappears from the project-grouped timeline but its assignments stay in the employee timeline, so per-person history survives. Unarchiving re-enables new assignments but does not restore what the wind-down removed.
+
+Deleting is permanent and removes the project together with **all** of its assignments, history included.
+
+The wind-down rules live in `app/services/lifecycle_service.py` and are shared with employee archiving.

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -1,6 +1,6 @@
 import { apiFetch } from "./client";
 import type { Project, ProjectCreateData } from "@/types/project";
-import type { DeleteResponse } from "@/types/common";
+import type { ProjectDeleteResponse } from "@/types/common";
 
 export function fetchProjects(
   search?: string,
@@ -32,9 +32,9 @@ export function updateProject(
 export function deleteProject(
   id: number,
   confirm = false,
-): Promise<DeleteResponse> {
+): Promise<ProjectDeleteResponse> {
   const params = confirm ? "?confirm=true" : "";
-  return apiFetch<DeleteResponse>(`/api/projects/${id}${params}`, {
+  return apiFetch<ProjectDeleteResponse>(`/api/projects/${id}${params}`, {
     method: "DELETE",
   });
 }

--- a/frontend/src/components/projects/ProjectList.tsx
+++ b/frontend/src/components/projects/ProjectList.tsx
@@ -222,14 +222,23 @@ export function ProjectList() {
         title="Archiwizuj projekt"
         description={
           archiveTarget ? (
-            <>
-              Czy na pewno chcesz zarchiwizować projekt{" "}
-              <strong>{archiveTarget.name}</strong>? Zakończone przypisania
-              pozostaną w historii, trwające zostaną skrócone do dzisiaj, a
-              przyszłe — usunięte. Nie będzie można dodać nowych. Projekt
-              zniknie z kalendarza projektów, ale pozostanie widoczny w
-              kalendarzu pracowników.
-            </>
+            <div className="space-y-2">
+              <p>
+                Czy na pewno chcesz zarchiwizować projekt{" "}
+                <strong>{archiveTarget.name}</strong>?
+              </p>
+              <p>Oznacza to, że:</p>
+              <ul className="list-disc space-y-1 pl-5">
+                <li>Zakończone assignmenty pozostaną w historii.</li>
+                <li>Trwające zostaną skrócone do dzisiaj.</li>
+                <li>Przyszłe zostaną usunięte.</li>
+              </ul>
+              <p>
+                Nie będzie można też do tego projektu dodać nowych
+                assignmentów. Projekt zniknie z kalendarza projektów, ale
+                pozostanie widoczny w kalendarzu pracowników.
+              </p>
+            </div>
           ) : (
             ""
           )
@@ -247,14 +256,18 @@ export function ProjectList() {
         title="Usuń projekt"
         description={
           crud.deleteTarget ? (
-            <>
-              Czy na pewno chcesz trwale usunąć projekt{" "}
-              <strong>{crud.deleteTarget.name}</strong>? Znikną wszystkie jego
-              przypisania — przeszłe, trwające i przyszłe — wraz z historią
-              obłożenia. Tej operacji nie da się cofnąć. Jeśli chcesz tylko
-              zakończyć projekt i zachować historię, zarchiwizuj go zamiast
-              usuwać.
-            </>
+            <div className="space-y-2">
+              <p>
+                Czy na pewno chcesz trwale usunąć projekt{" "}
+                <strong>{crud.deleteTarget.name}</strong>? Oznacza to, że
+                znikną też wszystkie assignmenty z nim związane. Jeśli chcesz
+                tylko zakończyć projekt i zachować historię, zarchiwizuj go
+                zamiast usuwać.
+              </p>
+              <p>
+                <strong>Tej operacji nie da się cofnąć.</strong>
+              </p>
+            </div>
           ) : (
             ""
           )

--- a/frontend/src/components/projects/ProjectList.tsx
+++ b/frontend/src/components/projects/ProjectList.tsx
@@ -224,9 +224,11 @@ export function ProjectList() {
           archiveTarget ? (
             <>
               Czy na pewno chcesz zarchiwizować projekt{" "}
-              <strong>{archiveTarget.name}</strong>? Istniejące assignmenty
-              pozostaną bez zmian, ale nie będzie można przypisać do niego
-              nowych.
+              <strong>{archiveTarget.name}</strong>? Zakończone przypisania
+              pozostaną w historii, trwające zostaną skrócone do dzisiaj, a
+              przyszłe — usunięte. Nie będzie można dodać nowych. Projekt
+              zniknie z kalendarza projektów, ale pozostanie widoczny w
+              kalendarzu pracowników.
             </>
           ) : (
             ""
@@ -246,9 +248,12 @@ export function ProjectList() {
         description={
           crud.deleteTarget ? (
             <>
-              Czy na pewno chcesz usunąć projekt{" "}
-              <strong>{crud.deleteTarget.name}</strong>? Przyszłe assignmenty
-              zostaną usunięte, a bieżące skrócone do dzisiaj.
+              Czy na pewno chcesz trwale usunąć projekt{" "}
+              <strong>{crud.deleteTarget.name}</strong>? Znikną wszystkie jego
+              przypisania — przeszłe, trwające i przyszłe — wraz z historią
+              obłożenia. Tej operacji nie da się cofnąć. Jeśli chcesz tylko
+              zakończyć projekt i zachować historię, zarchiwizuj go zamiast
+              usuwać.
             </>
           ) : (
             ""

--- a/frontend/src/components/timeline/Timeline.tsx
+++ b/frontend/src/components/timeline/Timeline.tsx
@@ -431,6 +431,9 @@ export function Timeline({ onNavigate }: TimelineProps = {}) {
   const handleNewAssignment = () => {
     setEditingAssignment(null);
     setDefaultEmployeeId(null);
+    // No placeholder intent here: reset it so a prior click in the placeholder
+    // row does not leak "Nieprzypisane" into a plain new assignment.
+    setDefaultUnassigned(false);
     setDefaultStartDate(null);
     setModalOpen(true);
   };

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -4,3 +4,11 @@ export interface DeleteResponse {
   active_assignments_count?: number;
   message?: string;
 }
+
+export interface ProjectDeleteResponse {
+  deleted?: boolean;
+  has_assignments?: boolean;
+  assignments_count?: number;
+  deleted_assignments?: number;
+  message?: string;
+}

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -2,7 +2,6 @@ export interface Project {
   id: number;
   name: string;
   color: string;
-  is_deleted: boolean;
   is_archived: boolean;
   created_at: string;
 }


### PR DESCRIPTION
Implements the **project** half of #73. Employees follow in part 2/2, reusing the same wind-down service unchanged.

> [!IMPORTANT]
> **Stacked on #77** — this PR is based on `fix/index-catchup-and-unassigned-reset`, not `main`.
> The new migration's `down_revision` is `m3b4c5d6e7f8`, which only exists in #77. Basing it on `l2a3b4c5d6e7` instead would leave two alembic heads once both PRs merge and force a merge revision, so stacking is the cleaner option. **Merge #77 first**, then retarget this PR to `main`.

## Model

A project is now **active**, **archived**, or **gone**. The soft-deleted state is removed entirely — `Project.is_deleted` is dropped from the model, schema, filters, guards and the frontend type.

## Archive — reversible wind-down

`POST /api/projects/{id}/archive` now winds down every assignment on the project, classified relative to today:

| Category | Condition | Action |
|---|---|---|
| Past | `end_date < today` | kept — historical occupancy survives |
| Ongoing | `start_date <= today <= end_date` | `end_date` trimmed to today |
| Future | `start_date > today` | deleted |

Boundary rules per the issue: `start_date == today` is **ongoing** (trimmed to a single day), not future; `end_date == today` is ongoing and needs no change.

Visibility follows the issue's matrix: archived projects leave `GET /api/projects/timeline` but their assignments stay in `GET /api/assignments/timeline`, so per-person history is intact. `project_timeline.py` now filters on `is_archived` where it previously filtered on `is_deleted`; the employee timeline needs no project filter at all.

Unarchive re-enables new assignments but does not restore what the wind-down removed.

## Delete — permanent

`DELETE /api/projects/{id}` hard-deletes the project **and all** of its assignments, history included.

The two-step confirmation now reports every assignment that would be destroyed, not just active ones. Since the old field names would be actively misleading, they are renamed:

- `has_active_assignments` → `has_assignments`
- `active_assignments_count` → `assignments_count`
- success adds `deleted_assignments`

The frontend declares these in `DeleteResponse` but never reads them, and always passes `?confirm=true`, so nothing on the client depends on the old names.

## Data migration — deviates from the issue, deliberately

The issue prescribes hard-deleting every existing `is_deleted = true` row. **This PR converts them to archived instead**, per product decision.

The reason is that soft-deleted projects are not actually invisible today. `calendar.py` never filtered on project state, so their assignments still render in the employee timeline. On the local database that is 15 past assignments across two projects that users can see right now — a blanket hard delete would erase them silently. Archiving matches the behaviour those projects already have and surfaces them in the project list, where they can be reviewed and deleted deliberately.

`downgrade()` restores the column but not which rows were once soft-deleted; that distinction is unrecoverable, and everything comes back as not-deleted so no project is resurrected into a hidden state.

## Shared service

Wind-down lives in `app/services/lifecycle_service.py` so employee archiving reuses it verbatim in part 2. The classification is a pure function (`classify_for_wind_down`), which keeps the boundary rules unit-testable — the repo has no database fixtures, so a DB-dependent design would have shipped untested.

Also folded in, because dropping `is_deleted` forced the code to be touched: `POST /assignments/{id}/duplicate` checked that the project was not soft-deleted. Duplicating creates a new assignment, so it now enforces the same archived-project guard as create and patch (409).

## Verification

- `pytest` — 79 passed, including 12 new boundary-rule tests covering every row of the table above plus the worked example from the issue
- `npx tsc --noEmit` — clean
- Migration applied to a live database: all three soft-deleted projects became archived, all 48 assignments preserved, column dropped
- `downgrade` → `upgrade` round-trip verified
- Wind-down exercised against the real database in a rolled-back transaction across all five boundary cases:

```
past    (ended 07-10)   2026-06-01..2026-07-10  =>  unchanged
ongoing (spans today)   2026-07-01..2026-08-31  =>  trimmed to 2026-08-06
starts exactly today    2026-08-06..2026-09-30  =>  trimmed to single day
ends exactly today      2026-07-01..2026-08-06  =>  unchanged
future  (starts 08-07)  2026-08-07..2026-09-30  =>  DELETED
```

Not verified over HTTP: the local admin password changed mid-session, so the endpoints were exercised at the service and database layer rather than through the API.

## Docs

`docs/api-reference.md` gains the archive/unarchive endpoints (previously undocumented), the wind-down table and the new delete contract. `docs/data-models.md` replaces "Deletion Rules" with lifecycle rules and drops `is_deleted` from the Project table.

Closes part 1 of #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)