### PR TITLE
feat: rework employee lifecycle into archive vs permanent delete (#73, part 2/2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,13 @@ cd frontend && npm run test
 - CSS: exclusively Tailwind utility classes + shadcn/ui
 - Naming: PascalCase components, camelCase functions, SCREAMING_SNAKE constants
 
+### UI Copy (Polish)
+
+- **Never use an em dash (`—`) inside a sentence.** It reads as machine-written. Use a comma, a full stop, or a colon introducing a bulleted list instead.
+- The `—` glyph is still correct where it is a symbol rather than punctuation: empty-value placeholders in tables (`{value || "—"}`) and neutral select options such as `— Brak —`. Do not rewrite those.
+- In confirmation dialogs, split the consequences into a bulleted list rather than one long sentence, and bold the irreversible part.
+- Name the consequence, not just the action: say what happens to existing data, not only that something will be archived or deleted.
+
 ## Key Business Rules
 
 - 1 FTE = 100% = 8h/day x working days/month

--- a/backend/alembic/versions/n4c5d6e7f8a9_project_lifecycle_archive_vs_delete.py
+++ b/backend/alembic/versions/n4c5d6e7f8a9_project_lifecycle_archive_vs_delete.py
@@ -1,0 +1,54 @@
+"""project_lifecycle_archive_vs_delete
+
+Rework the project lifecycle into two distinct operations: archive (reversible
+wind-down) and delete (permanent). Soft delete is removed — deletion is now a
+hard delete of the project and all of its assignments — so `is_deleted` becomes
+obsolete and is dropped.
+
+Existing soft-deleted projects are **converted to archived**, not hard-deleted.
+They are invisible in the UI today, yet their assignments still render in the
+employee timeline (that query never filtered on project state), so deleting
+them would silently erase historical occupancy that users can currently see.
+Archiving matches the behaviour they already have and surfaces them in the
+project list, where they can be reviewed and deleted deliberately.
+
+Revision ID: n4c5d6e7f8a9
+Revises: m3b4c5d6e7f8
+Create Date: 2026-08-06 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'n4c5d6e7f8a9'
+down_revision: Union[str, Sequence[str], None] = 'm3b4c5d6e7f8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Preserve soft-deleted projects as archived instead of dropping them.
+    op.execute(
+        "UPDATE projects SET is_archived = true WHERE is_deleted = true"
+    )
+    op.drop_column("projects", "is_deleted")
+
+
+def downgrade() -> None:
+    # The column comes back, but which archived projects were once soft-deleted
+    # is not recoverable — that distinction is gone for good. Everything is
+    # restored as not deleted, which keeps every project reachable rather than
+    # resurrecting rows into a hidden state.
+    op.add_column(
+        "projects",
+        sa.Column(
+            "is_deleted",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )

--- a/backend/alembic/versions/o5d6e7f8a9b0_employee_lifecycle_archive_vs_delete.py
+++ b/backend/alembic/versions/o5d6e7f8a9b0_employee_lifecycle_archive_vs_delete.py
@@ -1,0 +1,63 @@
+"""employee_lifecycle_archive_vs_delete
+
+Mirror the project lifecycle rework on employees: archive (reversible
+wind-down) and delete (permanent) replace soft delete, so `is_deleted` gives
+way to `is_archived`.
+
+Existing soft-deleted employees are **converted to archived**, not
+hard-deleted. Unlike projects, their assignments are already filtered out of
+the employee timeline today, so nothing visible changes either way — the
+choice is a product one: keep the rows so their history stays available under
+the project timeline and the archived list filter, and let deletion be a
+deliberate act rather than a side effect of a migration.
+
+Revision ID: o5d6e7f8a9b0
+Revises: n4c5d6e7f8a9
+Create Date: 2026-08-06 14:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'o5d6e7f8a9b0'
+down_revision: Union[str, Sequence[str], None] = 'n4c5d6e7f8a9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "employees",
+        sa.Column(
+            "is_archived",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    # Preserve soft-deleted employees as archived instead of dropping them.
+    op.execute(
+        "UPDATE employees SET is_archived = true WHERE is_deleted = true"
+    )
+    op.drop_column("employees", "is_deleted")
+
+
+def downgrade() -> None:
+    # Reinstating the column cannot recover which archived employees were once
+    # soft-deleted; that distinction is gone. Everything comes back as not
+    # deleted, which keeps every employee reachable rather than resurrecting
+    # rows into a hidden state.
+    op.add_column(
+        "employees",
+        sa.Column(
+            "is_deleted",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.drop_column("employees", "is_archived")

--- a/backend/app/api/assignments.py
+++ b/backend/app/api/assignments.py
@@ -103,11 +103,7 @@ async def create_assignment(
             raise HTTPException(status_code=404, detail="Employee not found")
 
     # Validate project exists and is not archived
-    proj = await db.execute(
-        select(Project).where(
-            Project.id == body.project_id, Project.is_deleted == False
-        )
-    )
+    proj = await db.execute(select(Project).where(Project.id == body.project_id))
     project = proj.scalar_one_or_none()
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
@@ -160,11 +156,7 @@ async def update_assignment(
             assignment.employee_id = body.employee_id
 
     if body.project_id is not None:
-        proj = await db.execute(
-            select(Project).where(
-                Project.id == body.project_id, Project.is_deleted == False
-            )
-        )
+        proj = await db.execute(select(Project).where(Project.id == body.project_id))
         project = proj.scalar_one_or_none()
         if not project:
             raise HTTPException(status_code=404, detail="Project not found")
@@ -268,7 +260,8 @@ async def duplicate_assignment(
     if not assignment:
         raise HTTPException(status_code=404, detail="Assignment not found")
 
-    # Validate employee and project are not soft-deleted
+    # Duplicating creates a new assignment, so it is subject to the same guards
+    # as create: the employee must not be deleted and the project not archived.
     # (placeholder assignments have no employee, so skip the employee check)
     if assignment.employee_id is not None:
         emp = await db.execute(
@@ -280,12 +273,16 @@ async def duplicate_assignment(
             raise HTTPException(status_code=400, detail="Cannot duplicate: employee has been deleted")
 
     proj = await db.execute(
-        select(Project).where(
-            Project.id == assignment.project_id, Project.is_deleted == False
-        )
+        select(Project).where(Project.id == assignment.project_id)
     )
-    if not proj.scalar_one_or_none():
-        raise HTTPException(status_code=400, detail="Cannot duplicate: project has been deleted")
+    project = proj.scalar_one_or_none()
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+    if project.is_archived:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Nie można przypisać pracownika do zarchiwizowanego projektu",
+        )
 
     new_assignment = Assignment(
         employee_id=assignment.employee_id,

--- a/backend/app/api/assignments.py
+++ b/backend/app/api/assignments.py
@@ -92,15 +92,20 @@ async def create_assignment(
             status_code=400, detail="Assignment must contain at least 1 working day"
         )
 
-    # Validate employee exists (skipped for placeholder assignments, employee_id is None)
+    # Validate employee exists and is not archived
+    # (skipped for placeholder assignments, employee_id is None)
     if body.employee_id is not None:
         emp = await db.execute(
-            select(Employee).where(
-                Employee.id == body.employee_id, Employee.is_deleted == False
-            )
+            select(Employee).where(Employee.id == body.employee_id)
         )
-        if not emp.scalar_one_or_none():
+        employee = emp.scalar_one_or_none()
+        if not employee:
             raise HTTPException(status_code=404, detail="Employee not found")
+        if employee.is_archived:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Nie można przypisać zarchiwizowanego pracownika",
+            )
 
     # Validate project exists and is not archived
     proj = await db.execute(select(Project).where(Project.id == body.project_id))
@@ -147,12 +152,16 @@ async def update_assignment(
             assignment.employee_id = None
         else:
             emp = await db.execute(
-                select(Employee).where(
-                    Employee.id == body.employee_id, Employee.is_deleted == False
-                )
+                select(Employee).where(Employee.id == body.employee_id)
             )
-            if not emp.scalar_one_or_none():
+            employee = emp.scalar_one_or_none()
+            if not employee:
                 raise HTTPException(status_code=404, detail="Employee not found")
+            if employee.is_archived:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Nie można przypisać zarchiwizowanego pracownika",
+                )
             assignment.employee_id = body.employee_id
 
     if body.project_id is not None:
@@ -261,16 +270,20 @@ async def duplicate_assignment(
         raise HTTPException(status_code=404, detail="Assignment not found")
 
     # Duplicating creates a new assignment, so it is subject to the same guards
-    # as create: the employee must not be deleted and the project not archived.
+    # as create: neither the employee nor the project may be archived.
     # (placeholder assignments have no employee, so skip the employee check)
     if assignment.employee_id is not None:
         emp = await db.execute(
-            select(Employee).where(
-                Employee.id == assignment.employee_id, Employee.is_deleted == False
-            )
+            select(Employee).where(Employee.id == assignment.employee_id)
         )
-        if not emp.scalar_one_or_none():
-            raise HTTPException(status_code=400, detail="Cannot duplicate: employee has been deleted")
+        employee = emp.scalar_one_or_none()
+        if not employee:
+            raise HTTPException(status_code=404, detail="Employee not found")
+        if employee.is_archived:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Nie można przypisać zarchiwizowanego pracownika",
+            )
 
     proj = await db.execute(
         select(Project).where(Project.id == assignment.project_id)

--- a/backend/app/api/calendar.py
+++ b/backend/app/api/calendar.py
@@ -71,7 +71,9 @@ async def get_timeline(
 ):
     """Return timeline data as per CLAUDE.md contract."""
     # Build employee query
-    emp_query = select(Employee).where(Employee.is_deleted == False)
+    # Archived employees leave this view; their assignments stay visible in the
+    # project timeline, which is what preserves the projects' history.
+    emp_query = select(Employee).where(Employee.is_archived == False)
     if team_ids:
         ids = parse_id_csv(team_ids)
         if ids:

--- a/backend/app/api/employees.py
+++ b/backend/app/api/employees.py
@@ -4,6 +4,7 @@ from typing import Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select, func as sa_func
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.dependencies import get_current_user, get_db, require_admin, require_editor
@@ -62,6 +63,25 @@ async def _ensure_email_available(
             status_code=status.HTTP_409_CONFLICT,
             detail="Pracownik z tym adresem email już istnieje",
         )
+
+
+async def _commit_handling_email_conflict(db: AsyncSession) -> None:
+    """Commit, translating a concurrent email-uniqueness violation into 409.
+
+    _ensure_email_available checks first, but two parallel requests can both
+    pass that SELECT; the unique constraint is the last line of defense and
+    would otherwise surface as a 500 with the session left in a broken state.
+    """
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        if "email" in str(exc.orig).lower():
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Pracownik z tym adresem email już istnieje",
+            ) from exc
+        raise
 
 
 async def _validate_team_id(db: AsyncSession, team_id: Optional[int]) -> None:
@@ -146,7 +166,7 @@ async def create_employee(
         technologies=technologies,
     )
     db.add(employee)
-    await db.commit()
+    await _commit_handling_email_conflict(db)
     await db.refresh(employee)
     return employee
 
@@ -176,7 +196,7 @@ async def update_employee(
         await _ensure_email_available(db, body.email, exclude_id=employee_id)
         employee.email = body.email if body.email else None
 
-    await db.commit()
+    await _commit_handling_email_conflict(db)
     await db.refresh(employee)
     return employee
 

--- a/backend/app/api/employees.py
+++ b/backend/app/api/employees.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from datetime import date
-from typing import Optional
+from typing import Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select, func as sa_func
@@ -12,6 +11,11 @@ from app.models.assignment import Assignment
 from app.models.employee import Employee, Team, Technology
 from app.models.user import User
 from app.schemas.employee import EmployeeCreate, EmployeeResponse, EmployeeUpdate
+from app.services.lifecycle_service import (
+    count_assignments,
+    delete_assignments,
+    wind_down_assignments,
+)
 from app.utils.query_params import parse_id_csv
 
 router = APIRouter(prefix="/api/employees", tags=["employees"])
@@ -52,13 +56,18 @@ async def list_employees(
     team_ids: Optional[str] = Query(None),
     technology_ids: Optional[str] = Query(None),
     search: Optional[str] = Query(None),
-    include_deleted: bool = Query(False),
+    employee_status: Literal["active", "archived", "all"] = Query(
+        "active", alias="status"
+    ),
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(get_current_user),
 ):
     query = select(Employee)
-    if not include_deleted:
-        query = query.where(Employee.is_deleted == False)
+    if employee_status == "active":
+        query = query.where(Employee.is_archived == False)
+    elif employee_status == "archived":
+        query = query.where(Employee.is_archived == True)
+    # "all" — no filter
     if team_ids:
         ids = parse_id_csv(team_ids)
         if ids:
@@ -90,11 +99,12 @@ async def create_employee(
     await _validate_team_id(db, body.team_id)
     technologies = await _resolve_technologies(db, body.technology_ids)
 
+    # Archived employees still count as taken, mirroring project names. They are
+    # reachable under the "archived" list filter, so the conflict is diagnosable.
     existing = await db.execute(
         select(Employee).where(
             sa_func.lower(Employee.first_name) == body.first_name.lower(),
             sa_func.lower(Employee.last_name) == body.last_name.lower(),
-            Employee.is_deleted == False,
         )
     )
     if existing.scalar_one_or_none():
@@ -152,46 +162,78 @@ async def delete_employee(
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(require_admin),
 ):
+    """Permanently delete an employee together with every one of their assignments.
+
+    Irreversible, and it drops past, ongoing and future assignments alike.
+    Archiving is the reversible alternative: it winds the employee down while
+    preserving history.
+    """
     result = await db.execute(select(Employee).where(Employee.id == employee_id))
     employee = result.scalar_one_or_none()
     if not employee:
         raise HTTPException(status_code=404, detail="Employee not found")
 
-    # Check for active assignments (end_date >= today)
-    today = date.today()
-    active_query = select(Assignment).where(
-        Assignment.employee_id == employee_id,
-        Assignment.end_date >= today,
-    )
-    active_result = await db.execute(active_query)
-    active_assignments = active_result.scalars().all()
+    assignment_filter = Assignment.employee_id == employee_id
+    assignments_count = await count_assignments(db, assignment_filter)
 
-    if active_assignments and not confirm:
+    if assignments_count and not confirm:
         return {
-            "has_active_assignments": True,
-            "active_assignments_count": len(active_assignments),
-            "active_assignments": [
-                {
-                    "id": a.id,
-                    "project_id": a.project_id,
-                    "start_date": a.start_date.isoformat(),
-                    "end_date": a.end_date.isoformat(),
-                }
-                for a in active_assignments
-            ],
-            "message": "Employee has active assignments. Pass ?confirm=true to proceed.",
+            "has_assignments": True,
+            "assignments_count": assignments_count,
+            "message": (
+                "Employee has assignments that will be permanently deleted. "
+                "Pass ?confirm=true to proceed."
+            ),
         }
 
-    # Soft delete employee
-    employee.is_deleted = True
+    deleted_assignments = await delete_assignments(db, assignment_filter)
+    await db.delete(employee)
+    await db.commit()
+    return {"deleted": True, "deleted_assignments": deleted_assignments}
 
-    # Delete future assignments
-    for a in active_assignments:
-        if a.start_date >= today:
-            await db.delete(a)
-        else:
-            # Trim ongoing assignment to today
-            a.end_date = today
+
+@router.post("/{employee_id}/archive", response_model=EmployeeResponse)
+async def archive_employee(
+    employee_id: int,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_editor),
+):
+    """Archive an employee and wind down their assignments.
+
+    Past assignments are preserved, ongoing ones are trimmed to end today, and
+    future ones are deleted. The employee stays in the database and their
+    history remains visible in the project timeline.
+    """
+    result = await db.execute(select(Employee).where(Employee.id == employee_id))
+    employee = result.scalar_one_or_none()
+    if not employee:
+        raise HTTPException(status_code=404, detail="Employee not found")
+
+    employee.is_archived = True
+    await wind_down_assignments(db, Assignment.employee_id == employee_id)
 
     await db.commit()
-    return {"deleted": True}
+    await db.refresh(employee)
+    return employee
+
+
+@router.post("/{employee_id}/unarchive", response_model=EmployeeResponse)
+async def unarchive_employee(
+    employee_id: int,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_editor),
+):
+    """Re-enable an archived employee for new assignments.
+
+    Does not restore assignments that archiving trimmed or deleted — archiving
+    is a wind-down, not a freeze.
+    """
+    result = await db.execute(select(Employee).where(Employee.id == employee_id))
+    employee = result.scalar_one_or_none()
+    if not employee:
+        raise HTTPException(status_code=404, detail="Employee not found")
+
+    employee.is_archived = False
+    await db.commit()
+    await db.refresh(employee)
+    return employee

--- a/backend/app/api/employees.py
+++ b/backend/app/api/employees.py
@@ -42,6 +42,28 @@ async def _resolve_technologies(
     return list(techs)
 
 
+async def _ensure_email_available(
+    db: AsyncSession, email: Optional[str], exclude_id: Optional[int] = None
+) -> None:
+    """Reject an email already used by another employee, with 409 rather than 500.
+
+    `employees.email` is unique in the database, so without this check a
+    collision surfaces as an unhandled IntegrityError. Archived employees keep
+    their address reserved, since the constraint does not care about state.
+    """
+    if not email:
+        return
+    query = select(Employee).where(sa_func.lower(Employee.email) == email.lower())
+    if exclude_id is not None:
+        query = query.where(Employee.id != exclude_id)
+    result = await db.execute(query)
+    if result.scalars().first():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Pracownik z tym adresem email już istnieje",
+        )
+
+
 async def _validate_team_id(db: AsyncSession, team_id: Optional[int]) -> None:
     """Ensure a team_id references an existing team (None is allowed)."""
     if team_id is None:
@@ -99,8 +121,9 @@ async def create_employee(
     await _validate_team_id(db, body.team_id)
     technologies = await _resolve_technologies(db, body.technology_ids)
 
-    # Archived employees still count as taken, mirroring project names. They are
-    # reachable under the "archived" list filter, so the conflict is diagnosable.
+    # Archived employees keep their name reserved, mirroring project names and
+    # the email rule below. They are reachable under the "archived" list filter,
+    # so the conflict is diagnosable and can be resolved by unarchiving.
     existing = await db.execute(
         select(Employee).where(
             sa_func.lower(Employee.first_name) == body.first_name.lower(),
@@ -112,6 +135,8 @@ async def create_employee(
             status_code=status.HTTP_409_CONFLICT,
             detail="Pracownik o tym imieniu i nazwisku już istnieje",
         )
+
+    await _ensure_email_available(db, body.email)
 
     employee = Employee(
         first_name=body.first_name,
@@ -148,6 +173,7 @@ async def update_employee(
     if body.technology_ids is not None:
         employee.technologies = await _resolve_technologies(db, body.technology_ids)
     if body.email is not None:
+        await _ensure_email_available(db, body.email, exclude_id=employee_id)
         employee.email = body.email if body.email else None
 
     await db.commit()

--- a/backend/app/api/project_timeline.py
+++ b/backend/app/api/project_timeline.py
@@ -27,8 +27,13 @@ async def get_project_timeline(
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(get_current_user),
 ):
-    """Return timeline data grouped by project."""
-    proj_query = select(Project).where(Project.is_deleted == False)
+    """Return timeline data grouped by project.
+
+    Archived projects are excluded so the project-grouped view stays focused on
+    live work; their assignments remain visible in the employee timeline, which
+    is what preserves historical occupancy.
+    """
+    proj_query = select(Project).where(Project.is_archived == False)
     if search and search.strip():
         proj_query = proj_query.where(Project.name.ilike(f"%{search.strip()}%"))
     proj_query = proj_query.order_by(Project.name)

--- a/backend/app/api/project_timeline.py
+++ b/backend/app/api/project_timeline.py
@@ -67,17 +67,15 @@ async def get_project_timeline(
     project_ids = [p.id for p in projects]
     assignments_by_project: dict[int, list] = {pid: [] for pid in project_ids}
     if project_ids:
-        active_employee_ids = select(Employee.id).where(Employee.is_deleted == False)
+        # No employee-state filter: archived employees stay visible here, so a
+        # project keeps the full picture of who worked on it. Placeholder
+        # assignments (employee_id IS NULL) are included for the same reason.
         a_result = await db.execute(
             select(Assignment)
             .where(
                 Assignment.project_id.in_(project_ids),
                 Assignment.start_date <= end_date,
                 Assignment.end_date >= start_date,
-                # Include placeholder assignments (employee_id IS NULL) alongside
-                # assignments held by active (non-deleted) employees.
-                Assignment.employee_id.in_(active_employee_ids)
-                | Assignment.employee_id.is_(None),
             )
             .order_by(Assignment.start_date)
         )

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import date
 from typing import Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -13,6 +12,11 @@ from app.models.assignment import Assignment
 from app.models.project import Project
 from app.models.user import User
 from app.schemas.project import ProjectCreate, ProjectResponse, ProjectUpdate
+from app.services.lifecycle_service import (
+    count_assignments,
+    delete_assignments,
+    wind_down_assignments,
+)
 
 router = APIRouter(prefix="/api/projects", tags=["projects"])
 
@@ -20,14 +24,11 @@ router = APIRouter(prefix="/api/projects", tags=["projects"])
 @router.get("", response_model=list[ProjectResponse])
 async def list_projects(
     search: Optional[str] = Query(None),
-    include_deleted: bool = Query(False),
     project_status: Literal["active", "archived", "all"] = Query("active", alias="status"),
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(get_current_user),
 ):
     query = select(Project)
-    if not include_deleted:
-        query = query.where(Project.is_deleted == False)
     if project_status == "active":
         query = query.where(Project.is_archived == False)
     elif project_status == "archived":
@@ -105,42 +106,34 @@ async def delete_project(
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(require_admin),
 ):
+    """Permanently delete a project together with every one of its assignments.
+
+    Irreversible, and it drops past, ongoing and future assignments alike.
+    Archiving is the reversible alternative: it winds the project down while
+    preserving history.
+    """
     result = await db.execute(select(Project).where(Project.id == project_id))
     project = result.scalar_one_or_none()
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
 
-    # Check for active assignments
-    today = date.today()
-    active_query = select(Assignment).where(
-        Assignment.project_id == project_id,
-        Assignment.end_date >= today,
-    )
-    active_result = await db.execute(active_query)
-    active_assignments = active_result.scalars().all()
+    assignment_filter = Assignment.project_id == project_id
+    assignments_count = await count_assignments(db, assignment_filter)
 
-    if active_assignments and not confirm:
+    if assignments_count and not confirm:
         return {
-            "has_active_assignments": True,
-            "active_assignments_count": len(active_assignments),
-            "message": "Project has active assignments. Pass ?confirm=true to proceed.",
+            "has_assignments": True,
+            "assignments_count": assignments_count,
+            "message": (
+                "Project has assignments that will be permanently deleted. "
+                "Pass ?confirm=true to proceed."
+            ),
         }
 
-    # Soft delete project
-    project.is_deleted = True
-
-    # Handle assignments like employee deletion:
-    # - Future assignments: remove
-    # - Ongoing assignments: trim end date to today
-    # - Historical assignments: preserve
-    for a in active_assignments:
-        if a.start_date >= today:
-            await db.delete(a)
-        else:
-            a.end_date = today
-
+    deleted_assignments = await delete_assignments(db, assignment_filter)
+    await db.delete(project)
     await db.commit()
-    return {"deleted": True}
+    return {"deleted": True, "deleted_assignments": deleted_assignments}
 
 
 @router.post("/{project_id}/archive", response_model=ProjectResponse)
@@ -149,14 +142,20 @@ async def archive_project(
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(require_editor),
 ):
+    """Archive a project and wind down its assignments.
+
+    Past assignments are preserved, ongoing ones are trimmed to end today, and
+    future ones are deleted. The project stays in the database and its history
+    remains visible in the employee timeline.
+    """
     result = await db.execute(select(Project).where(Project.id == project_id))
     project = result.scalar_one_or_none()
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
-    if project.is_deleted:
-        raise HTTPException(status_code=400, detail="Cannot archive a deleted project")
 
     project.is_archived = True
+    await wind_down_assignments(db, Assignment.project_id == project_id)
+
     await db.commit()
     await db.refresh(project)
     return project
@@ -168,13 +167,15 @@ async def unarchive_project(
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(require_editor),
 ):
+    """Re-enable an archived project for new assignments.
+
+    Does not restore assignments that archiving trimmed or deleted — archiving
+    is a wind-down, not a freeze.
+    """
     result = await db.execute(select(Project).where(Project.id == project_id))
     project = result.scalar_one_or_none()
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
-
-    if project.is_deleted:
-        raise HTTPException(status_code=400, detail="Cannot unarchive a deleted project")
 
     project.is_archived = False
     await db.commit()

--- a/backend/app/models/employee.py
+++ b/backend/app/models/employee.py
@@ -67,7 +67,9 @@ class Employee(Base):
         Integer, ForeignKey("teams.id"), nullable=True, index=True
     )
     email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True, unique=True)
-    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
+    is_archived: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false"
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -12,6 +12,5 @@ class Project(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
     color: Mapped[str] = mapped_column(String(7), nullable=False)
-    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
     is_archived: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/schemas/employee.py
+++ b/backend/app/schemas/employee.py
@@ -46,7 +46,7 @@ class EmployeeResponse(BaseModel):
     team: Optional[TeamResponse] = None
     technologies: list[TechnologyResponse] = []
     email: Optional[str] = None
-    is_deleted: bool
+    is_archived: bool
     created_at: datetime
 
     model_config = {"from_attributes": True}

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -37,7 +37,6 @@ class ProjectResponse(BaseModel):
     id: int
     name: str
     color: str
-    is_deleted: bool
     is_archived: bool
     created_at: datetime
 

--- a/backend/app/services/lifecycle_service.py
+++ b/backend/app/services/lifecycle_service.py
@@ -1,0 +1,107 @@
+"""Shared lifecycle operations for archivable resources (projects, employees).
+
+Archiving is a reversible *wind-down*, not a freeze: it stops new work and
+closes out work in flight, while leaving history intact. Deleting is permanent
+and takes every assignment with it.
+
+Both projects and employees follow identical rules, so the logic lives here
+rather than in either API module.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from enum import Enum
+
+from sqlalchemy import ColumnElement, delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.assignment import Assignment
+
+
+class WindDownAction(str, Enum):
+    """What archiving does to a single assignment."""
+
+    KEEP = "keep"
+    TRIM = "trim"
+    DELETE = "delete"
+
+
+@dataclass(frozen=True)
+class WindDownResult:
+    """How many assignments each wind-down branch touched."""
+
+    kept: int
+    trimmed: int
+    deleted: int
+
+
+def classify_for_wind_down(
+    start_date: date, end_date: date, today: date
+) -> WindDownAction:
+    """Decide what archiving does to an assignment, relative to `today`.
+
+    - **past** (`end_date < today`) — KEEP, so historical occupancy survives
+    - **ongoing** (`start_date <= today <= end_date`) — TRIM to end today
+    - **future** (`start_date > today`) — DELETE
+
+    Boundary rules are deliberate: an assignment starting today is ongoing and
+    gets trimmed to a single day rather than deleted, and one already ending
+    today is ongoing but needs no change, so it reports KEEP.
+    """
+    if end_date < today:
+        return WindDownAction.KEEP
+    if start_date > today:
+        return WindDownAction.DELETE
+    if end_date == today:
+        return WindDownAction.KEEP
+    return WindDownAction.TRIM
+
+
+async def wind_down_assignments(
+    db: AsyncSession,
+    condition: ColumnElement[bool],
+    today: date | None = None,
+) -> WindDownResult:
+    """Apply the archive wind-down to every assignment matching `condition`.
+
+    See `classify_for_wind_down` for the rules. Does not commit — the caller
+    owns the transaction.
+    """
+    today = today or date.today()
+
+    result = await db.execute(select(Assignment).where(condition))
+    kept = trimmed = deleted = 0
+
+    for assignment in result.scalars().all():
+        action = classify_for_wind_down(
+            assignment.start_date, assignment.end_date, today
+        )
+        if action is WindDownAction.DELETE:
+            await db.delete(assignment)
+            deleted += 1
+        elif action is WindDownAction.TRIM:
+            assignment.end_date = today
+            trimmed += 1
+        else:
+            kept += 1
+
+    return WindDownResult(kept=kept, trimmed=trimmed, deleted=deleted)
+
+
+async def count_assignments(db: AsyncSession, condition: ColumnElement[bool]) -> int:
+    """Count assignments matching `condition`."""
+    result = await db.execute(
+        select(func.count()).select_from(Assignment).where(condition)
+    )
+    return result.scalar_one()
+
+
+async def delete_assignments(db: AsyncSession, condition: ColumnElement[bool]) -> int:
+    """Hard-delete every assignment matching `condition`, returning the count.
+
+    Used by permanent deletion, which drops past, ongoing and future
+    assignments alike. Does not commit — the caller owns the transaction.
+    """
+    result = await db.execute(delete(Assignment).where(condition))
+    return result.rowcount or 0

--- a/backend/app/services/vacation_sync_service.py
+++ b/backend/app/services/vacation_sync_service.py
@@ -62,11 +62,12 @@ async def sync_vacations(db: AsyncSession, start_date: date, end_date: date) -> 
         logger.debug("Calamari not configured, skipping sync")
         return 0
 
-    # Get all employees with email set
+    # Get all employees with email set. Archived employees are wound down, so
+    # there is no point pulling fresh vacations for them.
     emp_result = await db.execute(
         select(Employee.id, Employee.email).where(
             Employee.email.isnot(None),
-            Employee.is_deleted == False,
+            Employee.is_archived == False,
         )
     )
     email_to_id: dict[str, int] = {}

--- a/backend/tests/test_employee_lifecycle.py
+++ b/backend/tests/test_employee_lifecycle.py
@@ -1,0 +1,53 @@
+"""Contract tests for the employee lifecycle rework.
+
+The wind-down rules themselves are shared with projects and covered in
+test_lifecycle_wind_down.py. What is pinned here is the API surface that
+changed: the response now reports `is_archived` and no longer `is_deleted`,
+and the list filter is a tri-state status rather than a boolean.
+"""
+
+from datetime import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.employee import EmployeeResponse
+
+BASE = {
+    "id": 1,
+    "first_name": "Anna",
+    "last_name": "Kowalska",
+    "created_at": datetime(2026, 1, 1),
+}
+
+
+class TestEmployeeResponseArchiveFlag:
+    def test_is_archived_is_reported(self):
+        emp = EmployeeResponse(**BASE, is_archived=True)
+        assert emp.is_archived is True
+
+    def test_is_archived_is_required(self):
+        with pytest.raises(ValidationError):
+            EmployeeResponse(**BASE)
+
+    def test_is_deleted_is_gone_from_the_contract(self):
+        # An old client sending is_deleted gets it ignored rather than echoed.
+        emp = EmployeeResponse(**BASE, is_archived=False, is_deleted=True)
+        assert not hasattr(emp, "is_deleted")
+        assert emp.is_archived is False
+
+
+class TestStatusFilterValues:
+    """The list endpoint accepts exactly active / archived / all."""
+
+    def test_accepted_values_match_projects(self):
+        from typing import get_args, get_type_hints
+
+        from app.api.employees import list_employees
+
+        hints = get_type_hints(list_employees)
+        assert set(get_args(hints["employee_status"])) == {
+            "active",
+            "archived",
+            "all",
+        }

--- a/backend/tests/test_lifecycle_wind_down.py
+++ b/backend/tests/test_lifecycle_wind_down.py
@@ -1,0 +1,86 @@
+"""Tests for the archive wind-down classification rules.
+
+The rules are shared by project and employee archiving, and the boundary cases
+(assignments starting or ending exactly today) are the ones most likely to
+regress, so they are pinned explicitly.
+"""
+
+from datetime import date
+
+from app.services.lifecycle_service import WindDownAction, classify_for_wind_down
+
+TODAY = date(2026, 7, 18)
+
+
+def classify(start: date, end: date) -> WindDownAction:
+    return classify_for_wind_down(start, end, TODAY)
+
+
+class TestPastAssignments:
+    def test_finished_before_today_is_kept(self):
+        assert (
+            classify(date(2026, 6, 1), date(2026, 7, 10)) is WindDownAction.KEEP
+        )
+
+    def test_ended_yesterday_is_kept(self):
+        assert (
+            classify(date(2026, 6, 1), date(2026, 7, 17)) is WindDownAction.KEEP
+        )
+
+    def test_long_finished_is_kept(self):
+        assert (
+            classify(date(2020, 1, 1), date(2020, 12, 31)) is WindDownAction.KEEP
+        )
+
+
+class TestOngoingAssignments:
+    def test_spanning_today_is_trimmed(self):
+        assert (
+            classify(date(2026, 7, 1), date(2026, 8, 31)) is WindDownAction.TRIM
+        )
+
+    def test_starting_today_is_ongoing_not_future(self):
+        # Trimmed to a single day rather than deleted.
+        assert (
+            classify(TODAY, date(2026, 9, 30)) is WindDownAction.TRIM
+        )
+
+    def test_ending_today_needs_no_change(self):
+        assert classify(date(2026, 7, 1), TODAY) is WindDownAction.KEEP
+
+    def test_single_day_today_needs_no_change(self):
+        assert classify(TODAY, TODAY) is WindDownAction.KEEP
+
+
+class TestFutureAssignments:
+    def test_starting_tomorrow_is_deleted(self):
+        assert (
+            classify(date(2026, 7, 19), date(2026, 8, 31))
+            is WindDownAction.DELETE
+        )
+
+    def test_far_future_is_deleted(self):
+        assert (
+            classify(date(2026, 8, 1), date(2026, 9, 30))
+            is WindDownAction.DELETE
+        )
+
+
+class TestIssueExample:
+    """The worked example from issue #73, with today = 2026-07-18."""
+
+    def test_finished_kept(self):
+        assert (
+            classify(date(2026, 6, 1), date(2026, 7, 10)) is WindDownAction.KEEP
+        )
+
+    def test_ongoing_trimmed(self):
+        assert (
+            classify(date(2026, 7, 1), date(2026, 8, 31)) is WindDownAction.TRIM
+        )
+
+    def test_future_deleted(self):
+        assert (
+            classify(date(2026, 8, 1), date(2026, 9, 30))
+            is WindDownAction.DELETE
+        )

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -46,14 +46,38 @@ On successful deletion: `{"deleted": true}` (200).
 ## Projects
 
 ```
-GET    /api/projects                        # List projects (200)
+GET    /api/projects                        # List projects (200, ?status=active|archived|all, default active)
 GET    /api/projects/timeline               # Timeline grouped by project (200, see below)
 POST   /api/projects                        # Create project, unique name (201)
 PATCH  /api/projects/{id}                   # Update project (200)
-DELETE /api/projects/{id}                   # Delete with cascade (200, see below)
+POST   /api/projects/{id}/archive           # Archive + wind down assignments (200, see below)
+POST   /api/projects/{id}/unarchive         # Re-enable for new assignments (200)
+DELETE /api/projects/{id}                   # Permanent delete with all assignments (200, see below)
 ```
 
-**Delete behavior:** Same two-step pattern as employees — returns active assignment info if `?confirm=true` is not passed.
+A project is either **active**, **archived**, or gone. There is no soft-deleted state.
+
+**Archive** is a reversible wind-down. Every assignment on the project is classified relative to today:
+
+| Category | Condition | Action |
+|---|---|---|
+| Past | `end_date < today` | kept untouched — historical occupancy is preserved |
+| Ongoing | `start_date <= today <= end_date` | `end_date` trimmed to today |
+| Future | `start_date > today` | deleted |
+
+Boundary rules: an assignment with `start_date == today` is *ongoing* (trimmed to a single day), not future; one with `end_date == today` is ongoing and needs no change.
+
+Archived projects are hidden from `GET /api/projects/timeline` but their assignments still appear in `GET /api/assignments/timeline`, so per-person history stays intact. Creating or patching an assignment onto an archived project returns 409, as does duplicating one.
+
+**Unarchive** re-enables the project for new assignments. It does **not** restore assignments that archiving trimmed or deleted.
+
+**Delete** is permanent: the project row and **all** of its assignments (past, ongoing and future) are removed. Two-step confirmation — without `?confirm=true`, a project that has any assignments returns them for confirmation instead of deleting:
+
+```json
+{"has_assignments": true, "assignments_count": 12, "message": "..."}
+```
+
+With `?confirm=true` (or when the project has no assignments): `{"deleted": true, "deleted_assignments": 12}`.
 
 ## Assignments
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -26,22 +26,29 @@ Login response includes `access_token`, `refresh_token`, and `token_type: "beare
 ## Employees
 
 ```
-GET    /api/employees                       # List employees (filter: ?team=Frontend&search=name)
+GET    /api/employees                       # List (?status=active|archived|all, default active; team_ids, technology_ids, search)
 POST   /api/employees                       # Create employee (201)
 PATCH  /api/employees/{id}                  # Update employee (200)
-DELETE /api/employees/{id}                  # Soft delete (200, see below)
+POST   /api/employees/{id}/archive          # Archive + wind down assignments (200, see below)
+POST   /api/employees/{id}/unarchive        # Re-enable for new assignments (200)
+DELETE /api/employees/{id}                  # Permanent delete with all assignments (200, see below)
 ```
 
-**Delete behavior:** If the employee has active assignments and `?confirm=true` is not passed, returns 200 with:
+An employee is either **active**, **archived**, or gone. There is no soft-deleted state. The lifecycle mirrors projects exactly; see the Projects section for the wind-down table, which is shared logic.
+
+**Archive** keeps past assignments, trims ongoing ones to end today, and deletes future ones. Archived employees are hidden from `GET /api/assignments/timeline` but their assignments still appear in `GET /api/projects/timeline`, so each project keeps the full record of who worked on it. Assigning an archived employee (create, patch or duplicate) returns 409.
+
+The visibility is deliberately the mirror image of projects: an archived **project** leaves the project timeline and stays in the employee one; an archived **employee** leaves the employee timeline and stays in the project one.
+
+**Unarchive** re-enables the employee for new assignments without restoring what the wind-down removed.
+
+**Delete** is permanent: the employee row and **all** of their assignments. Two-step confirmation — without `?confirm=true`, an employee with any assignments returns:
+
 ```json
-{
-  "has_active_assignments": true,
-  "active_assignments_count": 3,
-  "active_assignments": [{"id": 1, "project_id": 5, "start_date": "...", "end_date": "..."}],
-  "message": "Employee has active assignments. Pass ?confirm=true to proceed."
-}
+{"has_assignments": true, "assignments_count": 3, "message": "..."}
 ```
-On successful deletion: `{"deleted": true}` (200).
+
+With `?confirm=true` (or when they have none): `{"deleted": true, "deleted_assignments": 3}`.
 
 ## Projects
 

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -36,7 +36,7 @@
 | id | Integer | PK |
 | name | String | unique, not null |
 | color | String(7) | not null (hex color) |
-| is_deleted | Boolean | default false (soft delete) |
+| is_archived | Boolean | default false (wind-down state) |
 | created_at | DateTime | auto |
 
 ### Assignment
@@ -127,10 +127,16 @@ AppSettings (standalone — stores Calamari config etc.)
 - Vacation days reduce net available hours in occupancy calculations
 - Percentage allocations skip vacation days entirely; hours-based commitments stay fixed, so vacations can push occupancy above 100%
 
-### Deletion Rules
+### Lifecycle Rules
 
 | Entity | Behavior |
 |---|---|
 | **Employee** | Soft delete. Warning if active assignments exist. Future assignments removed, historical archived. |
-| **Project** | Soft delete. Cascade deletes all linked assignments (after confirmation). |
+| **Project** | Archive (reversible wind-down) or delete (permanent, takes all assignments). No soft-delete state. |
 | **Assignment** | Hard delete. Supports split and duplicate operations. |
+
+**Project archive vs delete.** Archiving winds a project down: past assignments are kept, ongoing ones are trimmed to end today, future ones are deleted, and no new assignments can be added (409). The project disappears from the project-grouped timeline but its assignments stay in the employee timeline, so per-person history survives. Unarchiving re-enables new assignments but does not restore what the wind-down removed.
+
+Deleting is permanent and removes the project together with **all** of its assignments, history included.
+
+The wind-down rules live in `app/services/lifecycle_service.py` and are shared with employee archiving.

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -26,7 +26,7 @@
 | last_name | String | not null |
 | email | String | nullable, unique |
 | team | Enum | nullable — BA, Backend, DevOps, Frontend, ML, Mobile, PM, QA, UX_UI_Designer |
-| is_deleted | Boolean | default false (soft delete) |
+| is_archived | Boolean | default false (wind-down state) |
 | created_at | DateTime | auto |
 
 ### Project
@@ -131,12 +131,21 @@ AppSettings (standalone — stores Calamari config etc.)
 
 | Entity | Behavior |
 |---|---|
-| **Employee** | Soft delete. Warning if active assignments exist. Future assignments removed, historical archived. |
+| **Employee** | Archive (reversible wind-down) or delete (permanent, takes all assignments). No soft-delete state. |
 | **Project** | Archive (reversible wind-down) or delete (permanent, takes all assignments). No soft-delete state. |
 | **Assignment** | Hard delete. Supports split and duplicate operations. |
 
-**Project archive vs delete.** Archiving winds a project down: past assignments are kept, ongoing ones are trimmed to end today, future ones are deleted, and no new assignments can be added (409). The project disappears from the project-grouped timeline but its assignments stay in the employee timeline, so per-person history survives. Unarchiving re-enables new assignments but does not restore what the wind-down removed.
+**Archive vs delete.** Archiving winds an entity down: past assignments are kept, ongoing ones are trimmed to end today, future ones are deleted, and no new assignments can reference it (409). Unarchiving re-enables new assignments but does not restore what the wind-down removed.
 
-Deleting is permanent and removes the project together with **all** of its assignments, history included.
+Deleting is permanent and removes the entity together with **all** of its assignments, history included.
 
-The wind-down rules live in `app/services/lifecycle_service.py` and are shared with employee archiving.
+The rules live in `app/services/lifecycle_service.py` and are identical for both entities.
+
+**Visibility.** Archiving hides the entity from its own timeline while keeping it in the other one, so history is never lost from both views at once:
+
+| State | Employee timeline | Project timeline |
+|---|:--:|:--:|
+| Active project | shown | shown |
+| Archived project | shown | hidden |
+| Active employee | shown | shown |
+| Archived employee | hidden | shown |

--- a/frontend/src/api/employees.ts
+++ b/frontend/src/api/employees.ts
@@ -6,14 +6,15 @@ export function fetchEmployees(
   teamIds?: number[],
   technologyIds?: number[],
   search?: string,
+  status: "active" | "archived" | "all" = "active",
 ): Promise<Employee[]> {
   const params = new URLSearchParams();
   if (teamIds && teamIds.length > 0) params.set("team_ids", teamIds.join(","));
   if (technologyIds && technologyIds.length > 0)
     params.set("technology_ids", technologyIds.join(","));
   if (search) params.set("search", search);
-  const qs = params.toString();
-  return apiFetch<Employee[]>(`/api/employees${qs ? `?${qs}` : ""}`);
+  params.set("status", status);
+  return apiFetch<Employee[]>(`/api/employees?${params.toString()}`);
 }
 
 export function createEmployee(data: EmployeeCreateData): Promise<Employee> {
@@ -40,6 +41,16 @@ export function deleteEmployee(
   const params = confirm ? "?confirm=true" : "";
   return apiFetch<DeleteResponse>(`/api/employees/${id}${params}`, {
     method: "DELETE",
+  });
+}
+
+export function archiveEmployee(id: number): Promise<Employee> {
+  return apiFetch<Employee>(`/api/employees/${id}/archive`, { method: "POST" });
+}
+
+export function unarchiveEmployee(id: number): Promise<Employee> {
+  return apiFetch<Employee>(`/api/employees/${id}/unarchive`, {
+    method: "POST",
   });
 }
 

--- a/frontend/src/components/assignments/AssignmentFormEmployeeProject.tsx
+++ b/frontend/src/components/assignments/AssignmentFormEmployeeProject.tsx
@@ -36,6 +36,11 @@ export function AssignmentFormEmployeeProject({
             {employees.map((emp) => (
               <SelectItem key={emp.id} value={String(emp.id)}>
                 {emp.last_name} {emp.first_name}
+                {emp.is_archived && (
+                  <span className="ml-2 text-xs text-muted-foreground">
+                    (zarchiwizowany)
+                  </span>
+                )}
               </SelectItem>
             ))}
           </SelectContent>

--- a/frontend/src/components/assignments/AssignmentModal.tsx
+++ b/frontend/src/components/assignments/AssignmentModal.tsx
@@ -39,9 +39,9 @@ export function AssignmentModal({
   const [isTentative, setIsTentative] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
-  const { data: employees = [] } = useQuery({
-    queryKey: ["employees"],
-    queryFn: () => fetchEmployees(),
+  const { data: activeEmployees = [], status: activeEmployeesStatus } = useQuery({
+    queryKey: ["employees", "active"],
+    queryFn: () => fetchEmployees(undefined, undefined, undefined, "active"),
     enabled: open,
   });
 
@@ -68,6 +68,32 @@ export function AssignmentModal({
         ...archivedProjects.filter((p) => p.id === currentProjectId),
       ]
     : allProjects;
+
+  // Same treatment for the assigned employee: archived people are not offered
+  // for new work, but the one already on this assignment has to stay visible,
+  // otherwise editing it from the project timeline shows an empty field.
+  const currentEmployeeId = isEditing ? (defaultEmployeeId ?? null) : null;
+  const isCurrentEmployeeActive = activeEmployees.some(
+    (e) => e.id === currentEmployeeId,
+  );
+
+  const { data: archivedEmployees = [] } = useQuery({
+    queryKey: ["employees", "archived"],
+    queryFn: () => fetchEmployees(undefined, undefined, undefined, "archived"),
+    enabled:
+      open &&
+      isEditing &&
+      currentEmployeeId !== null &&
+      activeEmployeesStatus === "success" &&
+      !isCurrentEmployeeActive,
+  });
+
+  const employees = isEditing
+    ? [
+        ...activeEmployees,
+        ...archivedEmployees.filter((e) => e.id === currentEmployeeId),
+      ]
+    : activeEmployees;
 
   useEffect(() => {
     if (!open) return;

--- a/frontend/src/components/employees/EmployeeList.tsx
+++ b/frontend/src/components/employees/EmployeeList.tsx
@@ -1,11 +1,21 @@
 import { useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { useCrudList } from "@/hooks/useCrudList";
 import { useClickOutside } from "@/hooks/useClickOutside";
 import { useTeams } from "@/hooks/useTeams";
 import { useTechnologies } from "@/hooks/useTechnologies";
-import { Pencil, Plus, Trash2, Users, Code2, X } from "lucide-react";
+import {
+  Archive,
+  ArchiveRestore,
+  Pencil,
+  Plus,
+  Trash2,
+  Users,
+  Code2,
+  X,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { DataTable } from "@/components/ui/DataTable";
@@ -15,21 +25,35 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { FilterButton } from "@/components/common/FilterButton";
 import { FilterChipPanel } from "@/components/common/FilterChipPanel";
+import { cn } from "@/lib/utils";
 import { pluralizePl } from "@/lib/pluralizePl";
 import {
+  archiveEmployee,
   createEmployee,
   deleteEmployee,
   fetchEmployees,
+  unarchiveEmployee,
   updateEmployee,
 } from "@/api/employees";
 import type { Employee, EmployeeCreateData } from "@/types/employee";
 import { EmployeeForm } from "./EmployeeForm";
 
+type StatusFilter = "active" | "archived" | "all";
+
 const EMPLOYEE_COLUMNS: DataTableColumn<Employee>[] = [
   {
     id: "name",
     header: "Nazwisko i imię",
-    cell: (emp) => `${emp.last_name} ${emp.first_name}`,
+    cell: (emp) => (
+      <span className="flex items-center gap-2">
+        {emp.last_name} {emp.first_name}
+        {emp.is_archived && (
+          <Badge variant="secondary" className="text-xs">
+            Zarchiwizowany
+          </Badge>
+        )}
+      </span>
+    ),
   },
   {
     id: "email",
@@ -67,6 +91,9 @@ const EMPLOYEE_COLUMNS: DataTableColumn<Employee>[] = [
 ];
 
 export function EmployeeList() {
+  const queryClient = useQueryClient();
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("active");
+  const [archiveTarget, setArchiveTarget] = useState<Employee | null>(null);
   const [selectedTeamIds, setSelectedTeamIds] = useState<number[]>([]);
   const [selectedTechnologyIds, setSelectedTechnologyIds] = useState<number[]>(
     [],
@@ -108,13 +135,36 @@ export function EmployeeList() {
       selectedTeamIds,
       selectedTechnologyIds,
       debouncedSearch,
+      statusFilter,
     ],
     queryFn: () =>
       fetchEmployees(
         selectedTeamIds.length > 0 ? selectedTeamIds : undefined,
         selectedTechnologyIds.length > 0 ? selectedTechnologyIds : undefined,
         debouncedSearch || undefined,
+        statusFilter,
       ),
+  });
+
+  const archiveMutation = useMutation({
+    mutationFn: (id: number) => archiveEmployee(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["employees"] });
+      queryClient.invalidateQueries({ queryKey: ["timeline"] });
+      toast.success("Pracownik zarchiwizowany");
+      setArchiveTarget(null);
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const unarchiveMutation = useMutation({
+    mutationFn: (id: number) => unarchiveEmployee(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["employees"] });
+      queryClient.invalidateQueries({ queryKey: ["timeline"] });
+      toast.success("Pracownik przywrócony");
+    },
+    onError: (err: Error) => toast.error(err.message),
   });
 
   const handleFormSubmit = (data: EmployeeCreateData) => {
@@ -129,7 +179,9 @@ export function EmployeeList() {
     employees.length === 0
       ? debouncedSearch || hasFilters
         ? `Brak wyników${debouncedSearch ? ` dla „${searchQuery}"` : ""}${hasFilters ? " dla wybranych filtrów" : ""}`
-        : "Brak pracowników. Dodaj pierwszego."
+        : statusFilter === "archived"
+          ? "Brak zarchiwizowanych pracowników."
+          : "Brak pracowników. Dodaj pierwszego."
       : undefined;
 
   return (
@@ -174,6 +226,30 @@ export function EmployeeList() {
               )
             }
           />
+          <div className="flex items-center gap-1">
+            {(
+              [
+                { value: "all", label: "Wszyscy" },
+                { value: "active", label: "Aktywni" },
+                { value: "archived", label: "Zarchiwizowani" },
+              ] as { value: StatusFilter; label: string }[]
+            ).map(({ value, label }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setStatusFilter(value)}
+                className={cn(
+                  "rounded-md border px-2 py-1 text-xs transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                  statusFilter === value
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:bg-muted",
+                )}
+                aria-pressed={statusFilter === value}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
           {(hasFilters || searchQuery.trim() !== "") && (
             <Button
               variant="ghost"
@@ -236,6 +312,26 @@ export function EmployeeList() {
             >
               <Pencil className="h-4 w-4" />
             </Button>
+            {emp.is_archived ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => unarchiveMutation.mutate(emp.id)}
+                disabled={unarchiveMutation.isPending}
+                aria-label={`Przywróć ${emp.last_name} ${emp.first_name}`}
+              >
+                <ArchiveRestore className="h-4 w-4" />
+              </Button>
+            ) : (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setArchiveTarget(emp)}
+                aria-label={`Archiwizuj ${emp.last_name} ${emp.first_name}`}
+              >
+                <Archive className="h-4 w-4" />
+              </Button>
+            )}
             <Button
               variant="ghost"
               size="sm"
@@ -262,19 +358,64 @@ export function EmployeeList() {
       />
 
       <ConfirmDialog
+        open={archiveTarget !== null}
+        onOpenChange={(o) => !o && setArchiveTarget(null)}
+        title="Archiwizuj pracownika"
+        description={
+          archiveTarget ? (
+            <div className="space-y-2">
+              <p>
+                Czy na pewno chcesz zarchiwizować pracownika{" "}
+                <strong>
+                  {archiveTarget.last_name} {archiveTarget.first_name}
+                </strong>
+                ?
+              </p>
+              <p>Oznacza to, że:</p>
+              <ul className="list-disc space-y-1 pl-5">
+                <li>Zakończone assignmenty pozostaną w historii.</li>
+                <li>Trwające zostaną skrócone do dzisiaj.</li>
+                <li>Przyszłe zostaną usunięte.</li>
+              </ul>
+              <p>
+                Nie będzie można też przypisać tego pracownika do nowych
+                projektów. Pracownik zniknie z kalendarza pracowników, ale
+                pozostanie widoczny w kalendarzu projektów.
+              </p>
+            </div>
+          ) : (
+            ""
+          )
+        }
+        confirmLabel="Archiwizuj"
+        pendingLabel="Archiwizowanie..."
+        onConfirm={() =>
+          archiveTarget && archiveMutation.mutate(archiveTarget.id)
+        }
+        isPending={archiveMutation.isPending}
+        contentClassName="max-w-md"
+      />
+
+      <ConfirmDialog
         open={crud.deleteTarget !== null}
         onOpenChange={(o) => !o && crud.setDeleteTarget(null)}
         title="Usuń pracownika"
         description={
           crud.deleteTarget ? (
-            <>
-              Czy na pewno chcesz usunąć pracownika{" "}
-              <strong>
-                {crud.deleteTarget.last_name} {crud.deleteTarget.first_name}
-              </strong>
-              ? Przyszłe assignmenty zostaną usunięte, a bieżące skrócone do
-              dzisiaj.
-            </>
+            <div className="space-y-2">
+              <p>
+                Czy na pewno chcesz trwale usunąć pracownika{" "}
+                <strong>
+                  {crud.deleteTarget.last_name} {crud.deleteTarget.first_name}
+                </strong>
+                ? Oznacza to, że znikną też wszystkie assignmenty z nim
+                związane. Jeśli chcesz tylko zakończyć współpracę i zachować
+                historię, zarchiwizuj go zamiast usuwać.
+              </p>
+              <p>
+                <strong>Tej operacji nie da się cofnąć.</strong>
+              </p>
+            </div>
           ) : (
             ""
           )

--- a/frontend/src/components/projects/ProjectList.tsx
+++ b/frontend/src/components/projects/ProjectList.tsx
@@ -222,14 +222,23 @@ export function ProjectList() {
         title="Archiwizuj projekt"
         description={
           archiveTarget ? (
-            <>
-              Czy na pewno chcesz zarchiwizować projekt{" "}
-              <strong>{archiveTarget.name}</strong>? Zakończone przypisania
-              pozostaną w historii, trwające zostaną skrócone do dzisiaj, a
-              przyszłe — usunięte. Nie będzie można dodać nowych. Projekt
-              zniknie z kalendarza projektów, ale pozostanie widoczny w
-              kalendarzu pracowników.
-            </>
+            <div className="space-y-2">
+              <p>
+                Czy na pewno chcesz zarchiwizować projekt{" "}
+                <strong>{archiveTarget.name}</strong>?
+              </p>
+              <p>Oznacza to, że:</p>
+              <ul className="list-disc space-y-1 pl-5">
+                <li>Zakończone assignmenty pozostaną w historii.</li>
+                <li>Trwające zostaną skrócone do dzisiaj.</li>
+                <li>Przyszłe zostaną usunięte.</li>
+              </ul>
+              <p>
+                Nie będzie można też do tego projektu dodać nowych
+                assignmentów. Projekt zniknie z kalendarza projektów, ale
+                pozostanie widoczny w kalendarzu pracowników.
+              </p>
+            </div>
           ) : (
             ""
           )
@@ -247,14 +256,18 @@ export function ProjectList() {
         title="Usuń projekt"
         description={
           crud.deleteTarget ? (
-            <>
-              Czy na pewno chcesz trwale usunąć projekt{" "}
-              <strong>{crud.deleteTarget.name}</strong>? Znikną wszystkie jego
-              przypisania — przeszłe, trwające i przyszłe — wraz z historią
-              obłożenia. Tej operacji nie da się cofnąć. Jeśli chcesz tylko
-              zakończyć projekt i zachować historię, zarchiwizuj go zamiast
-              usuwać.
-            </>
+            <div className="space-y-2">
+              <p>
+                Czy na pewno chcesz trwale usunąć projekt{" "}
+                <strong>{crud.deleteTarget.name}</strong>? Oznacza to, że
+                znikną też wszystkie assignmenty z nim związane. Jeśli chcesz
+                tylko zakończyć projekt i zachować historię, zarchiwizuj go
+                zamiast usuwać.
+              </p>
+              <p>
+                <strong>Tej operacji nie da się cofnąć.</strong>
+              </p>
+            </div>
           ) : (
             ""
           )

--- a/frontend/src/components/projects/ProjectList.tsx
+++ b/frontend/src/components/projects/ProjectList.tsx
@@ -224,9 +224,11 @@ export function ProjectList() {
           archiveTarget ? (
             <>
               Czy na pewno chcesz zarchiwizować projekt{" "}
-              <strong>{archiveTarget.name}</strong>? Istniejące assignmenty
-              pozostaną bez zmian, ale nie będzie można przypisać do niego
-              nowych.
+              <strong>{archiveTarget.name}</strong>? Zakończone przypisania
+              pozostaną w historii, trwające zostaną skrócone do dzisiaj, a
+              przyszłe — usunięte. Nie będzie można dodać nowych. Projekt
+              zniknie z kalendarza projektów, ale pozostanie widoczny w
+              kalendarzu pracowników.
             </>
           ) : (
             ""
@@ -246,9 +248,12 @@ export function ProjectList() {
         description={
           crud.deleteTarget ? (
             <>
-              Czy na pewno chcesz usunąć projekt{" "}
-              <strong>{crud.deleteTarget.name}</strong>? Przyszłe assignmenty
-              zostaną usunięte, a bieżące skrócone do dzisiaj.
+              Czy na pewno chcesz trwale usunąć projekt{" "}
+              <strong>{crud.deleteTarget.name}</strong>? Znikną wszystkie jego
+              przypisania — przeszłe, trwające i przyszłe — wraz z historią
+              obłożenia. Tej operacji nie da się cofnąć. Jeśli chcesz tylko
+              zakończyć projekt i zachować historię, zarchiwizuj go zamiast
+              usuwać.
             </>
           ) : (
             ""

--- a/frontend/src/types/assignment.ts
+++ b/frontend/src/types/assignment.ts
@@ -82,6 +82,8 @@ export interface AssignmentEmployeeOption {
   id: number;
   last_name: string;
   first_name: string;
+  /** Only ever true for the employee already on the assignment being edited. */
+  is_archived?: boolean;
 }
 
 export interface AssignmentProjectOption {

--- a/frontend/src/types/employee.ts
+++ b/frontend/src/types/employee.ts
@@ -8,7 +8,7 @@ export interface Employee {
   team: Team | null;
   technologies: Technology[];
   email: string | null;
-  is_deleted: boolean;
+  is_archived: boolean;
   created_at: string;
 }
 

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -2,7 +2,6 @@ export interface Project {
   id: number;
   name: string;
   color: string;
-  is_deleted: boolean;
   is_archived: boolean;
   created_at: string;
 }


### PR DESCRIPTION
Employee half of #73. Mirrors part 1 and reuses `lifecycle_service` unchanged.

> [!IMPORTANT]
> **Stacked on #78**, which is stacked on #77. Merge order: #77 → #78 → this. Retarget to `main` once #78 lands. The migration's `down_revision` is `n4c5d6e7f8a9`, which only exists in #78.

## Changes

An employee is now active, archived, or gone. `is_deleted` is dropped from the model, schema, filters, guards and the frontend type.

- **Archive** winds down assignments (past kept, ongoing trimmed to today, future deleted) and returns 409 on create, patch and duplicate.
- **Delete** is permanent, taking every assignment, with the same two-step confirmation and `has_assignments` / `assignments_count` shape as projects.
- **Visibility is the mirror of projects:** archived employees leave the employee timeline and stay in the project timeline, so each project keeps the full record of who worked on it. `project_timeline.py` therefore drops its employee-state filter entirely.
- **List** replaces the boolean `include_deleted` with `?status=active|archived|all` (default active). The employee list gains the matching filter control, archive/unarchive actions, an archived badge, and dialogs worded like the approved project ones.
- Vacation sync skips archived employees.
- Editing an assignment whose employee is archived previously showed a blank employee field, since the modal only fetched active employees. It now appends that one archived employee to the options, tagged `(zarchiwizowany)`, the same way archived projects are already handled.

## Migration

Existing soft-deleted employees are **converted to archived, not hard-deleted** (product decision, same as projects). Unlike projects their assignments were already hidden from the employee timeline, so nothing visible changes either way; keeping the rows means history stays reachable and deletion stays deliberate. On the local database that is 15 of 25 employees, so the default list view gets noticeably shorter.

`downgrade()` restores the column but not which rows were once soft-deleted; everything returns as not deleted.

## Beyond #73 (separate commit, `6a5b27e`)

Pre-existing bug, unrelated to this rework: a duplicate employee email hit the database UNIQUE constraint as an unhandled IntegrityError, so the user got "Internal Server Error" instead of being told the address is taken. Now a 409. Kept as its own commit so it can be dropped.

## Known and accepted

Editing an assignment held by an archived employee shows the employee correctly but returns 409 on save, because the modal always sends `employee_id` and the guard does not distinguish "keeping" from "moving". This matches how archived projects already behave on `main` and is accepted rather than fixed.

## Verification

83 tests pass (4 new), `tsc --noEmit` clean, migration applied to a live database (15 converted, 47 assignments untouched, column dropped).

Endpoints exercised against the real database via TestClient in a rolled-back transaction:

```
edit dates, assignment of an ARCHIVED EMPLOYEE  → 409  (accepted, see above)
edit dates, assignment on an ARCHIVED PROJECT   → 409  (pre-existing on main)
move an assignment onto an archived employee    → 409  (intended)
create an assignment for an archived employee   → 409  (intended)
```

Wind-down verified against the real database across all boundary cases: past unchanged, ongoing and starting-today trimmed to today, future deleted.

QA'd locally in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)