### PR TITLE
feat: add search to the employee, project and team dropdowns

### DIFF
--- a/backend/alembic/versions/o5d6e7f8a9b0_employee_lifecycle_archive_vs_delete.py
+++ b/backend/alembic/versions/o5d6e7f8a9b0_employee_lifecycle_archive_vs_delete.py
@@ -1,0 +1,63 @@
+"""employee_lifecycle_archive_vs_delete
+
+Mirror the project lifecycle rework on employees: archive (reversible
+wind-down) and delete (permanent) replace soft delete, so `is_deleted` gives
+way to `is_archived`.
+
+Existing soft-deleted employees are **converted to archived**, not
+hard-deleted. Unlike projects, their assignments are already filtered out of
+the employee timeline today, so nothing visible changes either way — the
+choice is a product one: keep the rows so their history stays available under
+the project timeline and the archived list filter, and let deletion be a
+deliberate act rather than a side effect of a migration.
+
+Revision ID: o5d6e7f8a9b0
+Revises: n4c5d6e7f8a9
+Create Date: 2026-08-06 14:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'o5d6e7f8a9b0'
+down_revision: Union[str, Sequence[str], None] = 'n4c5d6e7f8a9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "employees",
+        sa.Column(
+            "is_archived",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    # Preserve soft-deleted employees as archived instead of dropping them.
+    op.execute(
+        "UPDATE employees SET is_archived = true WHERE is_deleted = true"
+    )
+    op.drop_column("employees", "is_deleted")
+
+
+def downgrade() -> None:
+    # Reinstating the column cannot recover which archived employees were once
+    # soft-deleted; that distinction is gone. Everything comes back as not
+    # deleted, which keeps every employee reachable rather than resurrecting
+    # rows into a hidden state.
+    op.add_column(
+        "employees",
+        sa.Column(
+            "is_deleted",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.drop_column("employees", "is_archived")

--- a/backend/app/api/assignments.py
+++ b/backend/app/api/assignments.py
@@ -92,15 +92,20 @@ async def create_assignment(
             status_code=400, detail="Assignment must contain at least 1 working day"
         )
 
-    # Validate employee exists (skipped for placeholder assignments, employee_id is None)
+    # Validate employee exists and is not archived
+    # (skipped for placeholder assignments, employee_id is None)
     if body.employee_id is not None:
         emp = await db.execute(
-            select(Employee).where(
-                Employee.id == body.employee_id, Employee.is_deleted == False
-            )
+            select(Employee).where(Employee.id == body.employee_id)
         )
-        if not emp.scalar_one_or_none():
+        employee = emp.scalar_one_or_none()
+        if not employee:
             raise HTTPException(status_code=404, detail="Employee not found")
+        if employee.is_archived:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Nie można przypisać zarchiwizowanego pracownika",
+            )
 
     # Validate project exists and is not archived
     proj = await db.execute(select(Project).where(Project.id == body.project_id))
@@ -147,12 +152,16 @@ async def update_assignment(
             assignment.employee_id = None
         else:
             emp = await db.execute(
-                select(Employee).where(
-                    Employee.id == body.employee_id, Employee.is_deleted == False
-                )
+                select(Employee).where(Employee.id == body.employee_id)
             )
-            if not emp.scalar_one_or_none():
+            employee = emp.scalar_one_or_none()
+            if not employee:
                 raise HTTPException(status_code=404, detail="Employee not found")
+            if employee.is_archived:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Nie można przypisać zarchiwizowanego pracownika",
+                )
             assignment.employee_id = body.employee_id
 
     if body.project_id is not None:
@@ -261,16 +270,20 @@ async def duplicate_assignment(
         raise HTTPException(status_code=404, detail="Assignment not found")
 
     # Duplicating creates a new assignment, so it is subject to the same guards
-    # as create: the employee must not be deleted and the project not archived.
+    # as create: neither the employee nor the project may be archived.
     # (placeholder assignments have no employee, so skip the employee check)
     if assignment.employee_id is not None:
         emp = await db.execute(
-            select(Employee).where(
-                Employee.id == assignment.employee_id, Employee.is_deleted == False
-            )
+            select(Employee).where(Employee.id == assignment.employee_id)
         )
-        if not emp.scalar_one_or_none():
-            raise HTTPException(status_code=400, detail="Cannot duplicate: employee has been deleted")
+        employee = emp.scalar_one_or_none()
+        if not employee:
+            raise HTTPException(status_code=404, detail="Employee not found")
+        if employee.is_archived:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Nie można przypisać zarchiwizowanego pracownika",
+            )
 
     proj = await db.execute(
         select(Project).where(Project.id == assignment.project_id)

--- a/backend/app/api/calendar.py
+++ b/backend/app/api/calendar.py
@@ -71,7 +71,9 @@ async def get_timeline(
 ):
     """Return timeline data as per CLAUDE.md contract."""
     # Build employee query
-    emp_query = select(Employee).where(Employee.is_deleted == False)
+    # Archived employees leave this view; their assignments stay visible in the
+    # project timeline, which is what preserves the projects' history.
+    emp_query = select(Employee).where(Employee.is_archived == False)
     if team_ids:
         ids = parse_id_csv(team_ids)
         if ids:

--- a/backend/app/api/employees.py
+++ b/backend/app/api/employees.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from datetime import date
-from typing import Optional
+from typing import Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select, func as sa_func
@@ -12,6 +11,11 @@ from app.models.assignment import Assignment
 from app.models.employee import Employee, Team, Technology
 from app.models.user import User
 from app.schemas.employee import EmployeeCreate, EmployeeResponse, EmployeeUpdate
+from app.services.lifecycle_service import (
+    count_assignments,
+    delete_assignments,
+    wind_down_assignments,
+)
 from app.utils.query_params import parse_id_csv
 
 router = APIRouter(prefix="/api/employees", tags=["employees"])
@@ -52,13 +56,18 @@ async def list_employees(
     team_ids: Optional[str] = Query(None),
     technology_ids: Optional[str] = Query(None),
     search: Optional[str] = Query(None),
-    include_deleted: bool = Query(False),
+    employee_status: Literal["active", "archived", "all"] = Query(
+        "active", alias="status"
+    ),
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(get_current_user),
 ):
     query = select(Employee)
-    if not include_deleted:
-        query = query.where(Employee.is_deleted == False)
+    if employee_status == "active":
+        query = query.where(Employee.is_archived == False)
+    elif employee_status == "archived":
+        query = query.where(Employee.is_archived == True)
+    # "all" — no filter
     if team_ids:
         ids = parse_id_csv(team_ids)
         if ids:
@@ -90,11 +99,12 @@ async def create_employee(
     await _validate_team_id(db, body.team_id)
     technologies = await _resolve_technologies(db, body.technology_ids)
 
+    # Archived employees still count as taken, mirroring project names. They are
+    # reachable under the "archived" list filter, so the conflict is diagnosable.
     existing = await db.execute(
         select(Employee).where(
             sa_func.lower(Employee.first_name) == body.first_name.lower(),
             sa_func.lower(Employee.last_name) == body.last_name.lower(),
-            Employee.is_deleted == False,
         )
     )
     if existing.scalar_one_or_none():
@@ -152,46 +162,78 @@ async def delete_employee(
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(require_admin),
 ):
+    """Permanently delete an employee together with every one of their assignments.
+
+    Irreversible, and it drops past, ongoing and future assignments alike.
+    Archiving is the reversible alternative: it winds the employee down while
+    preserving history.
+    """
     result = await db.execute(select(Employee).where(Employee.id == employee_id))
     employee = result.scalar_one_or_none()
     if not employee:
         raise HTTPException(status_code=404, detail="Employee not found")
 
-    # Check for active assignments (end_date >= today)
-    today = date.today()
-    active_query = select(Assignment).where(
-        Assignment.employee_id == employee_id,
-        Assignment.end_date >= today,
-    )
-    active_result = await db.execute(active_query)
-    active_assignments = active_result.scalars().all()
+    assignment_filter = Assignment.employee_id == employee_id
+    assignments_count = await count_assignments(db, assignment_filter)
 
-    if active_assignments and not confirm:
+    if assignments_count and not confirm:
         return {
-            "has_active_assignments": True,
-            "active_assignments_count": len(active_assignments),
-            "active_assignments": [
-                {
-                    "id": a.id,
-                    "project_id": a.project_id,
-                    "start_date": a.start_date.isoformat(),
-                    "end_date": a.end_date.isoformat(),
-                }
-                for a in active_assignments
-            ],
-            "message": "Employee has active assignments. Pass ?confirm=true to proceed.",
+            "has_assignments": True,
+            "assignments_count": assignments_count,
+            "message": (
+                "Employee has assignments that will be permanently deleted. "
+                "Pass ?confirm=true to proceed."
+            ),
         }
 
-    # Soft delete employee
-    employee.is_deleted = True
+    deleted_assignments = await delete_assignments(db, assignment_filter)
+    await db.delete(employee)
+    await db.commit()
+    return {"deleted": True, "deleted_assignments": deleted_assignments}
 
-    # Delete future assignments
-    for a in active_assignments:
-        if a.start_date >= today:
-            await db.delete(a)
-        else:
-            # Trim ongoing assignment to today
-            a.end_date = today
+
+@router.post("/{employee_id}/archive", response_model=EmployeeResponse)
+async def archive_employee(
+    employee_id: int,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_editor),
+):
+    """Archive an employee and wind down their assignments.
+
+    Past assignments are preserved, ongoing ones are trimmed to end today, and
+    future ones are deleted. The employee stays in the database and their
+    history remains visible in the project timeline.
+    """
+    result = await db.execute(select(Employee).where(Employee.id == employee_id))
+    employee = result.scalar_one_or_none()
+    if not employee:
+        raise HTTPException(status_code=404, detail="Employee not found")
+
+    employee.is_archived = True
+    await wind_down_assignments(db, Assignment.employee_id == employee_id)
 
     await db.commit()
-    return {"deleted": True}
+    await db.refresh(employee)
+    return employee
+
+
+@router.post("/{employee_id}/unarchive", response_model=EmployeeResponse)
+async def unarchive_employee(
+    employee_id: int,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_editor),
+):
+    """Re-enable an archived employee for new assignments.
+
+    Does not restore assignments that archiving trimmed or deleted — archiving
+    is a wind-down, not a freeze.
+    """
+    result = await db.execute(select(Employee).where(Employee.id == employee_id))
+    employee = result.scalar_one_or_none()
+    if not employee:
+        raise HTTPException(status_code=404, detail="Employee not found")
+
+    employee.is_archived = False
+    await db.commit()
+    await db.refresh(employee)
+    return employee

--- a/backend/app/api/employees.py
+++ b/backend/app/api/employees.py
@@ -42,6 +42,28 @@ async def _resolve_technologies(
     return list(techs)
 
 
+async def _ensure_email_available(
+    db: AsyncSession, email: Optional[str], exclude_id: Optional[int] = None
+) -> None:
+    """Reject an email already used by another employee, with 409 rather than 500.
+
+    `employees.email` is unique in the database, so without this check a
+    collision surfaces as an unhandled IntegrityError. Archived employees keep
+    their address reserved, since the constraint does not care about state.
+    """
+    if not email:
+        return
+    query = select(Employee).where(sa_func.lower(Employee.email) == email.lower())
+    if exclude_id is not None:
+        query = query.where(Employee.id != exclude_id)
+    result = await db.execute(query)
+    if result.scalars().first():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Pracownik z tym adresem email już istnieje",
+        )
+
+
 async def _validate_team_id(db: AsyncSession, team_id: Optional[int]) -> None:
     """Ensure a team_id references an existing team (None is allowed)."""
     if team_id is None:
@@ -99,8 +121,9 @@ async def create_employee(
     await _validate_team_id(db, body.team_id)
     technologies = await _resolve_technologies(db, body.technology_ids)
 
-    # Archived employees still count as taken, mirroring project names. They are
-    # reachable under the "archived" list filter, so the conflict is diagnosable.
+    # Archived employees keep their name reserved, mirroring project names and
+    # the email rule below. They are reachable under the "archived" list filter,
+    # so the conflict is diagnosable and can be resolved by unarchiving.
     existing = await db.execute(
         select(Employee).where(
             sa_func.lower(Employee.first_name) == body.first_name.lower(),
@@ -112,6 +135,8 @@ async def create_employee(
             status_code=status.HTTP_409_CONFLICT,
             detail="Pracownik o tym imieniu i nazwisku już istnieje",
         )
+
+    await _ensure_email_available(db, body.email)
 
     employee = Employee(
         first_name=body.first_name,
@@ -148,6 +173,7 @@ async def update_employee(
     if body.technology_ids is not None:
         employee.technologies = await _resolve_technologies(db, body.technology_ids)
     if body.email is not None:
+        await _ensure_email_available(db, body.email, exclude_id=employee_id)
         employee.email = body.email if body.email else None
 
     await db.commit()

--- a/backend/app/api/project_timeline.py
+++ b/backend/app/api/project_timeline.py
@@ -67,17 +67,15 @@ async def get_project_timeline(
     project_ids = [p.id for p in projects]
     assignments_by_project: dict[int, list] = {pid: [] for pid in project_ids}
     if project_ids:
-        active_employee_ids = select(Employee.id).where(Employee.is_deleted == False)
+        # No employee-state filter: archived employees stay visible here, so a
+        # project keeps the full picture of who worked on it. Placeholder
+        # assignments (employee_id IS NULL) are included for the same reason.
         a_result = await db.execute(
             select(Assignment)
             .where(
                 Assignment.project_id.in_(project_ids),
                 Assignment.start_date <= end_date,
                 Assignment.end_date >= start_date,
-                # Include placeholder assignments (employee_id IS NULL) alongside
-                # assignments held by active (non-deleted) employees.
-                Assignment.employee_id.in_(active_employee_ids)
-                | Assignment.employee_id.is_(None),
             )
             .order_by(Assignment.start_date)
         )

--- a/backend/app/models/employee.py
+++ b/backend/app/models/employee.py
@@ -67,7 +67,9 @@ class Employee(Base):
         Integer, ForeignKey("teams.id"), nullable=True, index=True
     )
     email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True, unique=True)
-    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
+    is_archived: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false"
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/app/schemas/employee.py
+++ b/backend/app/schemas/employee.py
@@ -46,7 +46,7 @@ class EmployeeResponse(BaseModel):
     team: Optional[TeamResponse] = None
     technologies: list[TechnologyResponse] = []
     email: Optional[str] = None
-    is_deleted: bool
+    is_archived: bool
     created_at: datetime
 
     model_config = {"from_attributes": True}

--- a/backend/app/services/vacation_sync_service.py
+++ b/backend/app/services/vacation_sync_service.py
@@ -62,11 +62,12 @@ async def sync_vacations(db: AsyncSession, start_date: date, end_date: date) -> 
         logger.debug("Calamari not configured, skipping sync")
         return 0
 
-    # Get all employees with email set
+    # Get all employees with email set. Archived employees are wound down, so
+    # there is no point pulling fresh vacations for them.
     emp_result = await db.execute(
         select(Employee.id, Employee.email).where(
             Employee.email.isnot(None),
-            Employee.is_deleted == False,
+            Employee.is_archived == False,
         )
     )
     email_to_id: dict[str, int] = {}

--- a/backend/tests/test_employee_lifecycle.py
+++ b/backend/tests/test_employee_lifecycle.py
@@ -1,0 +1,53 @@
+"""Contract tests for the employee lifecycle rework.
+
+The wind-down rules themselves are shared with projects and covered in
+test_lifecycle_wind_down.py. What is pinned here is the API surface that
+changed: the response now reports `is_archived` and no longer `is_deleted`,
+and the list filter is a tri-state status rather than a boolean.
+"""
+
+from datetime import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.employee import EmployeeResponse
+
+BASE = {
+    "id": 1,
+    "first_name": "Anna",
+    "last_name": "Kowalska",
+    "created_at": datetime(2026, 1, 1),
+}
+
+
+class TestEmployeeResponseArchiveFlag:
+    def test_is_archived_is_reported(self):
+        emp = EmployeeResponse(**BASE, is_archived=True)
+        assert emp.is_archived is True
+
+    def test_is_archived_is_required(self):
+        with pytest.raises(ValidationError):
+            EmployeeResponse(**BASE)
+
+    def test_is_deleted_is_gone_from_the_contract(self):
+        # An old client sending is_deleted gets it ignored rather than echoed.
+        emp = EmployeeResponse(**BASE, is_archived=False, is_deleted=True)
+        assert not hasattr(emp, "is_deleted")
+        assert emp.is_archived is False
+
+
+class TestStatusFilterValues:
+    """The list endpoint accepts exactly active / archived / all."""
+
+    def test_accepted_values_match_projects(self):
+        from typing import get_args, get_type_hints
+
+        from app.api.employees import list_employees
+
+        hints = get_type_hints(list_employees)
+        assert set(get_args(hints["employee_status"])) == {
+            "active",
+            "archived",
+            "all",
+        }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -26,22 +26,29 @@ Login response includes `access_token`, `refresh_token`, and `token_type: "beare
 ## Employees
 
 ```
-GET    /api/employees                       # List employees (filter: ?team=Frontend&search=name)
+GET    /api/employees                       # List (?status=active|archived|all, default active; team_ids, technology_ids, search)
 POST   /api/employees                       # Create employee (201)
 PATCH  /api/employees/{id}                  # Update employee (200)
-DELETE /api/employees/{id}                  # Soft delete (200, see below)
+POST   /api/employees/{id}/archive          # Archive + wind down assignments (200, see below)
+POST   /api/employees/{id}/unarchive        # Re-enable for new assignments (200)
+DELETE /api/employees/{id}                  # Permanent delete with all assignments (200, see below)
 ```
 
-**Delete behavior:** If the employee has active assignments and `?confirm=true` is not passed, returns 200 with:
+An employee is either **active**, **archived**, or gone. There is no soft-deleted state. The lifecycle mirrors projects exactly; see the Projects section for the wind-down table, which is shared logic.
+
+**Archive** keeps past assignments, trims ongoing ones to end today, and deletes future ones. Archived employees are hidden from `GET /api/assignments/timeline` but their assignments still appear in `GET /api/projects/timeline`, so each project keeps the full record of who worked on it. Assigning an archived employee (create, patch or duplicate) returns 409.
+
+The visibility is deliberately the mirror image of projects: an archived **project** leaves the project timeline and stays in the employee one; an archived **employee** leaves the employee timeline and stays in the project one.
+
+**Unarchive** re-enables the employee for new assignments without restoring what the wind-down removed.
+
+**Delete** is permanent: the employee row and **all** of their assignments. Two-step confirmation — without `?confirm=true`, an employee with any assignments returns:
+
 ```json
-{
-  "has_active_assignments": true,
-  "active_assignments_count": 3,
-  "active_assignments": [{"id": 1, "project_id": 5, "start_date": "...", "end_date": "..."}],
-  "message": "Employee has active assignments. Pass ?confirm=true to proceed."
-}
+{"has_assignments": true, "assignments_count": 3, "message": "..."}
 ```
-On successful deletion: `{"deleted": true}` (200).
+
+With `?confirm=true` (or when they have none): `{"deleted": true, "deleted_assignments": 3}`.
 
 ## Projects
 

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -26,7 +26,7 @@
 | last_name | String | not null |
 | email | String | nullable, unique |
 | team | Enum | nullable — BA, Backend, DevOps, Frontend, ML, Mobile, PM, QA, UX_UI_Designer |
-| is_deleted | Boolean | default false (soft delete) |
+| is_archived | Boolean | default false (wind-down state) |
 | created_at | DateTime | auto |
 
 ### Project
@@ -131,12 +131,21 @@ AppSettings (standalone — stores Calamari config etc.)
 
 | Entity | Behavior |
 |---|---|
-| **Employee** | Soft delete. Warning if active assignments exist. Future assignments removed, historical archived. |
+| **Employee** | Archive (reversible wind-down) or delete (permanent, takes all assignments). No soft-delete state. |
 | **Project** | Archive (reversible wind-down) or delete (permanent, takes all assignments). No soft-delete state. |
 | **Assignment** | Hard delete. Supports split and duplicate operations. |
 
-**Project archive vs delete.** Archiving winds a project down: past assignments are kept, ongoing ones are trimmed to end today, future ones are deleted, and no new assignments can be added (409). The project disappears from the project-grouped timeline but its assignments stay in the employee timeline, so per-person history survives. Unarchiving re-enables new assignments but does not restore what the wind-down removed.
+**Archive vs delete.** Archiving winds an entity down: past assignments are kept, ongoing ones are trimmed to end today, future ones are deleted, and no new assignments can reference it (409). Unarchiving re-enables new assignments but does not restore what the wind-down removed.
 
-Deleting is permanent and removes the project together with **all** of its assignments, history included.
+Deleting is permanent and removes the entity together with **all** of its assignments, history included.
 
-The wind-down rules live in `app/services/lifecycle_service.py` and are shared with employee archiving.
+The rules live in `app/services/lifecycle_service.py` and are identical for both entities.
+
+**Visibility.** Archiving hides the entity from its own timeline while keeping it in the other one, so history is never lost from both views at once:
+
+| State | Employee timeline | Project timeline |
+|---|:--:|:--:|
+| Active project | shown | shown |
+| Archived project | shown | hidden |
+| Active employee | shown | shown |
+| Archived employee | hidden | shown |

--- a/frontend/src/api/employees.ts
+++ b/frontend/src/api/employees.ts
@@ -6,14 +6,15 @@ export function fetchEmployees(
   teamIds?: number[],
   technologyIds?: number[],
   search?: string,
+  status: "active" | "archived" | "all" = "active",
 ): Promise<Employee[]> {
   const params = new URLSearchParams();
   if (teamIds && teamIds.length > 0) params.set("team_ids", teamIds.join(","));
   if (technologyIds && technologyIds.length > 0)
     params.set("technology_ids", technologyIds.join(","));
   if (search) params.set("search", search);
-  const qs = params.toString();
-  return apiFetch<Employee[]>(`/api/employees${qs ? `?${qs}` : ""}`);
+  params.set("status", status);
+  return apiFetch<Employee[]>(`/api/employees?${params.toString()}`);
 }
 
 export function createEmployee(data: EmployeeCreateData): Promise<Employee> {
@@ -40,6 +41,16 @@ export function deleteEmployee(
   const params = confirm ? "?confirm=true" : "";
   return apiFetch<DeleteResponse>(`/api/employees/${id}${params}`, {
     method: "DELETE",
+  });
+}
+
+export function archiveEmployee(id: number): Promise<Employee> {
+  return apiFetch<Employee>(`/api/employees/${id}/archive`, { method: "POST" });
+}
+
+export function unarchiveEmployee(id: number): Promise<Employee> {
+  return apiFetch<Employee>(`/api/employees/${id}/unarchive`, {
+    method: "POST",
   });
 }
 

--- a/frontend/src/components/assignments/AssignmentFormEmployeeProject.tsx
+++ b/frontend/src/components/assignments/AssignmentFormEmployeeProject.tsx
@@ -36,6 +36,11 @@ export function AssignmentFormEmployeeProject({
             {employees.map((emp) => (
               <SelectItem key={emp.id} value={String(emp.id)}>
                 {emp.last_name} {emp.first_name}
+                {emp.is_archived && (
+                  <span className="ml-2 text-xs text-muted-foreground">
+                    (zarchiwizowany)
+                  </span>
+                )}
               </SelectItem>
             ))}
           </SelectContent>

--- a/frontend/src/components/assignments/AssignmentFormEmployeeProject.tsx
+++ b/frontend/src/components/assignments/AssignmentFormEmployeeProject.tsx
@@ -1,11 +1,6 @@
+import { useMemo } from "react";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { SearchableSelect } from "@/components/common/SearchableSelect";
 import type { AssignmentFormEmployeeProjectProps } from "@/types/assignment";
 
 export function AssignmentFormEmployeeProject({
@@ -17,34 +12,50 @@ export function AssignmentFormEmployeeProject({
   projects,
   employeeError,
 }: AssignmentFormEmployeeProjectProps) {
+  const employeeOptions = useMemo(
+    () => [
+      { value: "none", label: "— Nieprzypisane (placeholder) —" },
+      ...employees.map((emp) => ({
+        value: String(emp.id),
+        label: `${emp.last_name} ${emp.first_name}`,
+        hint: emp.is_archived ? "(zarchiwizowany)" : undefined,
+      })),
+    ],
+    [employees],
+  );
+
+  const projectOptions = useMemo(
+    () =>
+      projects.map((proj) => ({
+        value: String(proj.id),
+        label: proj.name,
+        content: (
+          <span className="flex items-center gap-2 truncate">
+            <span
+              className="inline-block h-3 w-3 shrink-0 rounded-full ring-1 ring-border"
+              style={{ backgroundColor: proj.color }}
+            />
+            <span className="truncate">{proj.name}</span>
+          </span>
+        ),
+      })),
+    [projects],
+  );
+
   return (
     <>
       <div className="space-y-2">
-        <Label htmlFor="assignment-employee">Pracownik</Label>
-        <Select value={employeeId} onValueChange={onEmployeeChange}>
-          <SelectTrigger
-            id="assignment-employee"
-            className="w-full"
-            aria-invalid={!!employeeError}
-          >
-            <SelectValue placeholder="Wybierz pracownika" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="none">
-              — Nieprzypisane (placeholder) —
-            </SelectItem>
-            {employees.map((emp) => (
-              <SelectItem key={emp.id} value={String(emp.id)}>
-                {emp.last_name} {emp.first_name}
-                {emp.is_archived && (
-                  <span className="ml-2 text-xs text-muted-foreground">
-                    (zarchiwizowany)
-                  </span>
-                )}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <Label id="assignment-employee-label">Pracownik</Label>
+        <SearchableSelect
+          id="assignment-employee"
+          labelId="assignment-employee-label"
+          options={employeeOptions}
+          value={employeeId}
+          onChange={onEmployeeChange}
+          placeholder="Wybierz pracownika"
+          searchPlaceholder="Szukaj pracownika..."
+          invalid={!!employeeError}
+        />
         {employeeError && (
           <p className="text-sm text-destructive" role="alert">
             {employeeError}
@@ -53,25 +64,16 @@ export function AssignmentFormEmployeeProject({
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="assignment-project">Projekt</Label>
-        <Select value={projectId} onValueChange={onProjectChange}>
-          <SelectTrigger id="assignment-project" className="w-full">
-            <SelectValue placeholder="Wybierz projekt" />
-          </SelectTrigger>
-          <SelectContent>
-            {projects.map((proj) => (
-              <SelectItem key={proj.id} value={String(proj.id)}>
-                <span className="flex items-center gap-2">
-                  <span
-                    className="inline-block h-3 w-3 rounded-full ring-1 ring-border"
-                    style={{ backgroundColor: proj.color }}
-                  />
-                  {proj.name}
-                </span>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <Label id="assignment-project-label">Projekt</Label>
+        <SearchableSelect
+          id="assignment-project"
+          labelId="assignment-project-label"
+          options={projectOptions}
+          value={projectId}
+          onChange={onProjectChange}
+          placeholder="Wybierz projekt"
+          searchPlaceholder="Szukaj projektu..."
+        />
       </div>
     </>
   );

--- a/frontend/src/components/assignments/AssignmentModal.tsx
+++ b/frontend/src/components/assignments/AssignmentModal.tsx
@@ -39,9 +39,9 @@ export function AssignmentModal({
   const [isTentative, setIsTentative] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
-  const { data: employees = [] } = useQuery({
-    queryKey: ["employees"],
-    queryFn: () => fetchEmployees(),
+  const { data: activeEmployees = [], status: activeEmployeesStatus } = useQuery({
+    queryKey: ["employees", "active"],
+    queryFn: () => fetchEmployees(undefined, undefined, undefined, "active"),
     enabled: open,
   });
 
@@ -68,6 +68,32 @@ export function AssignmentModal({
         ...archivedProjects.filter((p) => p.id === currentProjectId),
       ]
     : allProjects;
+
+  // Same treatment for the assigned employee: archived people are not offered
+  // for new work, but the one already on this assignment has to stay visible,
+  // otherwise editing it from the project timeline shows an empty field.
+  const currentEmployeeId = isEditing ? (defaultEmployeeId ?? null) : null;
+  const isCurrentEmployeeActive = activeEmployees.some(
+    (e) => e.id === currentEmployeeId,
+  );
+
+  const { data: archivedEmployees = [] } = useQuery({
+    queryKey: ["employees", "archived"],
+    queryFn: () => fetchEmployees(undefined, undefined, undefined, "archived"),
+    enabled:
+      open &&
+      isEditing &&
+      currentEmployeeId !== null &&
+      activeEmployeesStatus === "success" &&
+      !isCurrentEmployeeActive,
+  });
+
+  const employees = isEditing
+    ? [
+        ...activeEmployees,
+        ...archivedEmployees.filter((e) => e.id === currentEmployeeId),
+      ]
+    : activeEmployees;
 
   useEffect(() => {
     if (!open) return;

--- a/frontend/src/components/common/MultiSelectField.tsx
+++ b/frontend/src/components/common/MultiSelectField.tsx
@@ -1,6 +1,18 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { ChevronDown, X, Check } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { usePopoverPanel } from "@/hooks/usePopoverPanel";
 import { cn } from "@/lib/utils";
+
+/** Row height in px; rows are single-line, so the list height is predictable. */
+const ROW_HEIGHT = 32;
+const MAX_LIST_HEIGHT = 288;
+/** Search input plus the panel's own padding, on top of the list height. */
+const SEARCH_BOX_HEIGHT = 54;
 
 export interface MultiSelectOption {
   id: number;
@@ -14,6 +26,8 @@ interface MultiSelectFieldProps {
   placeholder?: string;
   isLoading?: boolean;
   emptyLabel?: string;
+  /** Id of the field's <Label>. See SearchableSelect for why not `htmlFor`. */
+  labelId?: string;
 }
 
 /**
@@ -27,22 +41,25 @@ export function MultiSelectField({
   placeholder = "Wybierz...",
   isLoading,
   emptyLabel = "Brak opcji",
+  labelId,
 }: MultiSelectFieldProps) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
-  const ref = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-        setSearch("");
-      }
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [open]);
+  const { triggerRef, container, side, preparePanel } = usePopoverPanel();
+
+  /** Height of the panel with nothing filtered out; decides where it opens. */
+  const panelHeight =
+    Math.min(Math.max(options.length, 1) * ROW_HEIGHT, MAX_LIST_HEIGHT) +
+    SEARCH_BOX_HEIGHT;
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (next) {
+      preparePanel(panelHeight);
+      setSearch("");
+    }
+  };
 
   const selectedOptions = useMemo(
     () => options.filter((o) => selectedIds.includes(o.id)),
@@ -62,12 +79,8 @@ export function MultiSelectField({
     );
 
   return (
-    <div className="relative" ref={ref}>
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="flex min-h-9 w-full flex-wrap items-center gap-1 rounded-md border border-input bg-transparent px-2 py-1.5 text-left text-sm shadow-xs transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      >
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger ref={triggerRef} aria-labelledby={labelId} className="flex min-h-9 w-full flex-wrap items-center gap-1 rounded-md border border-input bg-transparent px-2 py-1.5 text-left text-sm shadow-xs transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
         {selectedOptions.length === 0 ? (
           <span className="text-muted-foreground">{placeholder}</span>
         ) : (
@@ -93,54 +106,57 @@ export function MultiSelectField({
           ))
         )}
         <ChevronDown className="ml-auto h-4 w-4 shrink-0 text-muted-foreground" />
-      </button>
+      </PopoverTrigger>
 
-      {open && (
-        <div className="absolute left-0 top-full z-30 mt-1 w-full rounded-md border bg-background p-1 shadow-md">
-          <input
-            autoFocus
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Szukaj..."
-            className="mb-1 w-full rounded-sm border-b bg-transparent px-2 py-1.5 text-sm outline-none"
-          />
-          <div className="max-h-48 overflow-y-auto">
-            {isLoading ? (
-              <p className="px-2 py-2 text-xs text-muted-foreground">
-                Ładowanie...
-              </p>
-            ) : filtered.length === 0 ? (
-              <p className="px-2 py-2 text-xs text-muted-foreground">
-                {options.length === 0 ? emptyLabel : "Brak wyników"}
-              </p>
-            ) : (
-              filtered.map((o) => {
-                const isSelected = selectedIds.includes(o.id);
-                return (
-                  <button
-                    key={o.id}
-                    type="button"
-                    onClick={() => toggle(o.id)}
-                    className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-muted"
+      <PopoverContent
+        container={container}
+        side={side}
+        className="flex max-h-(--radix-popover-content-available-height) w-(--radix-popover-trigger-width) flex-col p-1"
+      >
+        <input
+          autoFocus
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Szukaj..."
+          aria-label="Szukaj"
+          className="mb-1 w-full shrink-0 rounded-sm border-b bg-transparent px-2 py-1.5 text-sm outline-none"
+        />
+        <div className="min-h-0 max-h-72 flex-1 overflow-y-auto">
+          {isLoading ? (
+            <p className="px-2 py-2 text-xs text-muted-foreground">
+              Ładowanie...
+            </p>
+          ) : filtered.length === 0 ? (
+            <p className="px-2 py-2 text-xs text-muted-foreground">
+              {options.length === 0 ? emptyLabel : "Brak wyników"}
+            </p>
+          ) : (
+            filtered.map((o) => {
+              const isSelected = selectedIds.includes(o.id);
+              return (
+                <button
+                  key={o.id}
+                  type="button"
+                  onClick={() => toggle(o.id)}
+                  className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-muted"
+                >
+                  <span
+                    className={cn(
+                      "flex h-4 w-4 shrink-0 items-center justify-center rounded border",
+                      isSelected
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-input",
+                    )}
                   >
-                    <span
-                      className={cn(
-                        "flex h-4 w-4 shrink-0 items-center justify-center rounded border",
-                        isSelected
-                          ? "border-primary bg-primary text-primary-foreground"
-                          : "border-input",
-                      )}
-                    >
-                      {isSelected && <Check className="h-3 w-3" />}
-                    </span>
-                    {o.name}
-                  </button>
-                );
-              })
-            )}
-          </div>
+                    {isSelected && <Check className="h-3 w-3" />}
+                  </span>
+                  {o.name}
+                </button>
+              );
+            })
+          )}
         </div>
-      )}
-    </div>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/frontend/src/components/common/MultiSelectField.tsx
+++ b/frontend/src/components/common/MultiSelectField.tsx
@@ -6,6 +6,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { usePopoverPanel } from "@/hooks/usePopoverPanel";
+import { normalizeForSearch } from "@/lib/normalizeForSearch";
 import { cn } from "@/lib/utils";
 
 /** Row height in px; rows are single-line, so the list height is predictable. */
@@ -67,8 +68,10 @@ export function MultiSelectField({
   );
 
   const filtered = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    return q ? options.filter((o) => o.name.toLowerCase().includes(q)) : options;
+    const q = normalizeForSearch(search.trim());
+    return q
+      ? options.filter((o) => normalizeForSearch(o.name).includes(q))
+      : options;
   }, [options, search]);
 
   const toggle = (id: number) =>

--- a/frontend/src/components/common/SearchableSelect.tsx
+++ b/frontend/src/components/common/SearchableSelect.tsx
@@ -1,0 +1,226 @@
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { Check, ChevronDown } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { usePopoverPanel } from "@/hooks/usePopoverPanel";
+import { cn } from "@/lib/utils";
+
+/** Row height in px; rows are single-line, so the list height is predictable. */
+const ROW_HEIGHT = 32;
+const MAX_LIST_HEIGHT = 288;
+/** Search input plus the panel's own padding, on top of the list height. */
+const SEARCH_BOX_HEIGHT = 54;
+
+export interface SearchableSelectOption {
+  value: string;
+  /** Plain text used for searching and as the trigger label fallback. */
+  label: string;
+  /** Custom rendering for the row and the trigger (e.g. a project color dot). */
+  content?: ReactNode;
+  /** Muted suffix shown after the label, e.g. "(zarchiwizowany)". */
+  hint?: string;
+}
+
+interface SearchableSelectProps {
+  options: SearchableSelectOption[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  isLoading?: boolean;
+  emptyLabel?: string;
+  disabled?: boolean;
+  /** Rendered on the trigger, for tests and for focusing the field. */
+  id?: string;
+  /**
+   * Id of the field's <Label>. Deliberately not wired with `htmlFor`: the browser
+   * forwards a label click to the labelled control, which would immediately
+   * reopen the panel that the same click just dismissed.
+   */
+  labelId?: string;
+  invalid?: boolean;
+  className?: string;
+}
+
+/**
+ * Single-choice dropdown with a search box, for lists too long to scan by eye
+ * (employees, projects, teams). Visually matches the plain Select trigger.
+ */
+export function SearchableSelect({
+  options,
+  value,
+  onChange,
+  placeholder = "Wybierz...",
+  searchPlaceholder = "Szukaj...",
+  isLoading,
+  emptyLabel = "Brak opcji",
+  disabled,
+  id,
+  labelId,
+  invalid,
+  className,
+}: SearchableSelectProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [highlight, setHighlight] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+  const { triggerRef, container, side, preparePanel } = usePopoverPanel();
+
+  /** Height of the panel with nothing filtered out; decides where it opens. */
+  const panelHeight =
+    Math.min(Math.max(options.length, 1) * ROW_HEIGHT, MAX_LIST_HEIGHT) +
+    SEARCH_BOX_HEIGHT;
+
+  const selected = useMemo(
+    () => options.find((o) => o.value === value),
+    [options, value],
+  );
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return q
+      ? options.filter((o) => o.label.toLowerCase().includes(q))
+      : options;
+  }, [options, search]);
+
+  // Derived, so filtering the list can never leave the highlight past its end.
+  const activeIndex = Math.min(highlight, Math.max(filtered.length - 1, 0));
+
+  // Deferred by a frame: right after opening, Radix has not positioned the panel
+  // yet, and scrolling an unlaid-out box does nothing.
+  useEffect(() => {
+    if (!open) return;
+    const frame = requestAnimationFrame(() => {
+      listRef.current
+        ?.querySelector('[data-highlighted="true"]')
+        ?.scrollIntoView({ block: "nearest" });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [activeIndex, open]);
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (next) {
+      preparePanel(panelHeight);
+      setSearch("");
+      const index = options.findIndex((o) => o.value === value);
+      setHighlight(index === -1 ? 0 : index);
+    }
+  };
+
+  const select = (next: string) => {
+    onChange(next);
+    setOpen(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      if (filtered.length === 0) return;
+      const step = e.key === "ArrowDown" ? 1 : -1;
+      setHighlight((activeIndex + step + filtered.length) % filtered.length);
+      return;
+    }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      const option = filtered[activeIndex];
+      if (option) select(option.value);
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger
+        ref={triggerRef}
+        id={id}
+        disabled={disabled}
+        aria-labelledby={labelId}
+        aria-invalid={invalid}
+        className={cn(
+          "border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 dark:bg-input/30 dark:hover:bg-input/50 flex h-9 w-full items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+      >
+        <span className="flex min-w-0 items-center gap-2 truncate">
+          {selected ? (
+            <>
+              {selected.content ?? selected.label}
+              {selected.hint && (
+                <span className="text-xs text-muted-foreground">
+                  {selected.hint}
+                </span>
+              )}
+            </>
+          ) : (
+            <span className="text-muted-foreground">
+              {isLoading ? "Ładowanie..." : placeholder}
+            </span>
+          )}
+        </span>
+        <ChevronDown className="size-4 shrink-0 opacity-50" />
+      </PopoverTrigger>
+
+      <PopoverContent
+        container={container}
+        side={side}
+        className="flex max-h-(--radix-popover-content-available-height) w-(--radix-popover-trigger-width) flex-col p-1"
+      >
+        <input
+          autoFocus
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setHighlight(0);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder={searchPlaceholder}
+          aria-label={searchPlaceholder}
+          className="mb-1 w-full shrink-0 rounded-sm border-b bg-transparent px-2 py-1.5 text-sm outline-none"
+        />
+        <div
+          ref={listRef}
+          className="min-h-0 max-h-72 flex-1 overflow-y-auto"
+        >
+          {isLoading ? (
+            <p className="px-2 py-2 text-xs text-muted-foreground">
+              Ładowanie...
+            </p>
+          ) : filtered.length === 0 ? (
+            <p className="px-2 py-2 text-xs text-muted-foreground">
+              {options.length === 0 ? emptyLabel : "Brak wyników"}
+            </p>
+          ) : (
+            filtered.map((option, index) => (
+              <button
+                key={option.value}
+                type="button"
+                data-highlighted={index === highlight}
+                onMouseEnter={() => setHighlight(index)}
+                onClick={() => select(option.value)}
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm data-[highlighted=true]:bg-accent data-[highlighted=true]:text-accent-foreground"
+              >
+                <Check
+                  className={cn(
+                    "size-4 shrink-0",
+                    option.value === value ? "opacity-100" : "opacity-0",
+                  )}
+                />
+                <span className="min-w-0 flex-1 truncate">
+                  {option.content ?? option.label}
+                </span>
+                {option.hint && (
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {option.hint}
+                  </span>
+                )}
+              </button>
+            ))
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/src/components/common/SearchableSelect.tsx
+++ b/frontend/src/components/common/SearchableSelect.tsx
@@ -6,6 +6,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { usePopoverPanel } from "@/hooks/usePopoverPanel";
+import { normalizeForSearch } from "@/lib/normalizeForSearch";
 import { cn } from "@/lib/utils";
 
 /** Row height in px; rows are single-line, so the list height is predictable. */
@@ -80,9 +81,9 @@ export function SearchableSelect({
   );
 
   const filtered = useMemo(() => {
-    const q = search.trim().toLowerCase();
+    const q = normalizeForSearch(search.trim());
     return q
-      ? options.filter((o) => o.label.toLowerCase().includes(q))
+      ? options.filter((o) => normalizeForSearch(o.label).includes(q))
       : options;
   }, [options, search]);
 
@@ -197,7 +198,7 @@ export function SearchableSelect({
               <button
                 key={option.value}
                 type="button"
-                data-highlighted={index === highlight}
+                data-highlighted={index === activeIndex}
                 onMouseEnter={() => setHighlight(index)}
                 onClick={() => select(option.value)}
                 className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm data-[highlighted=true]:bg-accent data-[highlighted=true]:text-accent-foreground"

--- a/frontend/src/components/employees/EmployeeForm.tsx
+++ b/frontend/src/components/employees/EmployeeForm.tsx
@@ -1,15 +1,9 @@
-import { type FormEvent, useEffect, useState } from "react";
+import { type FormEvent, useEffect, useMemo, useState } from "react";
 import { DialogWrapper } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { MultiSelectField } from "@/components/common/MultiSelectField";
+import { SearchableSelect } from "@/components/common/SearchableSelect";
 import { useTeams } from "@/hooks/useTeams";
 import { useTechnologies } from "@/hooks/useTechnologies";
 import type { Employee, EmployeeFormProps } from "@/types/employee";
@@ -48,6 +42,14 @@ export function EmployeeForm({
   useEffect(() => {
     setForm(initialFormState(employee));
   }, [employee]);
+
+  const teamOptions = useMemo(
+    () => [
+      { value: "none", label: "— Brak —" },
+      ...teams.map((t) => ({ value: String(t.id), label: t.name })),
+    ],
+    [teams],
+  );
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -106,27 +108,22 @@ export function EmployeeForm({
         </p>
       </div>
       <div className="space-y-2">
-        <Label>Zespół</Label>
-        <Select
+        <Label id="employee-team-label">Zespół</Label>
+        <SearchableSelect
+          id="employee-team"
+          labelId="employee-team-label"
+          options={teamOptions}
           value={form.teamId}
-          onValueChange={(v) => setForm((f) => ({ ...f, teamId: v }))}
-        >
-          <SelectTrigger className="w-full">
-            <SelectValue placeholder={teamsLoading ? "Ładowanie..." : undefined} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="none">— Brak —</SelectItem>
-            {teams.map((t) => (
-              <SelectItem key={t.id} value={String(t.id)}>
-                {t.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          onChange={(v) => setForm((f) => ({ ...f, teamId: v }))}
+          isLoading={teamsLoading}
+          searchPlaceholder="Szukaj zespołu..."
+          emptyLabel="Brak zespołów. Dodaj je w Ustawieniach"
+        />
       </div>
       <div className="space-y-2">
-        <Label>Technologie</Label>
+        <Label id="employee-technologies-label">Technologie</Label>
         <MultiSelectField
+          labelId="employee-technologies-label"
           options={technologies}
           selectedIds={form.technologyIds}
           onChange={(ids) => setForm((f) => ({ ...f, technologyIds: ids }))}

--- a/frontend/src/components/employees/EmployeeList.tsx
+++ b/frontend/src/components/employees/EmployeeList.tsx
@@ -1,11 +1,21 @@
 import { useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { useCrudList } from "@/hooks/useCrudList";
 import { useClickOutside } from "@/hooks/useClickOutside";
 import { useTeams } from "@/hooks/useTeams";
 import { useTechnologies } from "@/hooks/useTechnologies";
-import { Pencil, Plus, Trash2, Users, Code2, X } from "lucide-react";
+import {
+  Archive,
+  ArchiveRestore,
+  Pencil,
+  Plus,
+  Trash2,
+  Users,
+  Code2,
+  X,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { DataTable } from "@/components/ui/DataTable";
@@ -15,21 +25,35 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { FilterButton } from "@/components/common/FilterButton";
 import { FilterChipPanel } from "@/components/common/FilterChipPanel";
+import { cn } from "@/lib/utils";
 import { pluralizePl } from "@/lib/pluralizePl";
 import {
+  archiveEmployee,
   createEmployee,
   deleteEmployee,
   fetchEmployees,
+  unarchiveEmployee,
   updateEmployee,
 } from "@/api/employees";
 import type { Employee, EmployeeCreateData } from "@/types/employee";
 import { EmployeeForm } from "./EmployeeForm";
 
+type StatusFilter = "active" | "archived" | "all";
+
 const EMPLOYEE_COLUMNS: DataTableColumn<Employee>[] = [
   {
     id: "name",
     header: "Nazwisko i imię",
-    cell: (emp) => `${emp.last_name} ${emp.first_name}`,
+    cell: (emp) => (
+      <span className="flex items-center gap-2">
+        {emp.last_name} {emp.first_name}
+        {emp.is_archived && (
+          <Badge variant="secondary" className="text-xs">
+            Zarchiwizowany
+          </Badge>
+        )}
+      </span>
+    ),
   },
   {
     id: "email",
@@ -67,6 +91,9 @@ const EMPLOYEE_COLUMNS: DataTableColumn<Employee>[] = [
 ];
 
 export function EmployeeList() {
+  const queryClient = useQueryClient();
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("active");
+  const [archiveTarget, setArchiveTarget] = useState<Employee | null>(null);
   const [selectedTeamIds, setSelectedTeamIds] = useState<number[]>([]);
   const [selectedTechnologyIds, setSelectedTechnologyIds] = useState<number[]>(
     [],
@@ -108,13 +135,36 @@ export function EmployeeList() {
       selectedTeamIds,
       selectedTechnologyIds,
       debouncedSearch,
+      statusFilter,
     ],
     queryFn: () =>
       fetchEmployees(
         selectedTeamIds.length > 0 ? selectedTeamIds : undefined,
         selectedTechnologyIds.length > 0 ? selectedTechnologyIds : undefined,
         debouncedSearch || undefined,
+        statusFilter,
       ),
+  });
+
+  const archiveMutation = useMutation({
+    mutationFn: (id: number) => archiveEmployee(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["employees"] });
+      queryClient.invalidateQueries({ queryKey: ["timeline"] });
+      toast.success("Pracownik zarchiwizowany");
+      setArchiveTarget(null);
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const unarchiveMutation = useMutation({
+    mutationFn: (id: number) => unarchiveEmployee(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["employees"] });
+      queryClient.invalidateQueries({ queryKey: ["timeline"] });
+      toast.success("Pracownik przywrócony");
+    },
+    onError: (err: Error) => toast.error(err.message),
   });
 
   const handleFormSubmit = (data: EmployeeCreateData) => {
@@ -129,7 +179,9 @@ export function EmployeeList() {
     employees.length === 0
       ? debouncedSearch || hasFilters
         ? `Brak wyników${debouncedSearch ? ` dla „${searchQuery}"` : ""}${hasFilters ? " dla wybranych filtrów" : ""}`
-        : "Brak pracowników. Dodaj pierwszego."
+        : statusFilter === "archived"
+          ? "Brak zarchiwizowanych pracowników."
+          : "Brak pracowników. Dodaj pierwszego."
       : undefined;
 
   return (
@@ -174,6 +226,30 @@ export function EmployeeList() {
               )
             }
           />
+          <div className="flex items-center gap-1">
+            {(
+              [
+                { value: "all", label: "Wszyscy" },
+                { value: "active", label: "Aktywni" },
+                { value: "archived", label: "Zarchiwizowani" },
+              ] as { value: StatusFilter; label: string }[]
+            ).map(({ value, label }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setStatusFilter(value)}
+                className={cn(
+                  "rounded-md border px-2 py-1 text-xs transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                  statusFilter === value
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:bg-muted",
+                )}
+                aria-pressed={statusFilter === value}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
           {(hasFilters || searchQuery.trim() !== "") && (
             <Button
               variant="ghost"
@@ -236,6 +312,26 @@ export function EmployeeList() {
             >
               <Pencil className="h-4 w-4" />
             </Button>
+            {emp.is_archived ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => unarchiveMutation.mutate(emp.id)}
+                disabled={unarchiveMutation.isPending}
+                aria-label={`Przywróć ${emp.last_name} ${emp.first_name}`}
+              >
+                <ArchiveRestore className="h-4 w-4" />
+              </Button>
+            ) : (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setArchiveTarget(emp)}
+                aria-label={`Archiwizuj ${emp.last_name} ${emp.first_name}`}
+              >
+                <Archive className="h-4 w-4" />
+              </Button>
+            )}
             <Button
               variant="ghost"
               size="sm"
@@ -262,19 +358,64 @@ export function EmployeeList() {
       />
 
       <ConfirmDialog
+        open={archiveTarget !== null}
+        onOpenChange={(o) => !o && setArchiveTarget(null)}
+        title="Archiwizuj pracownika"
+        description={
+          archiveTarget ? (
+            <div className="space-y-2">
+              <p>
+                Czy na pewno chcesz zarchiwizować pracownika{" "}
+                <strong>
+                  {archiveTarget.last_name} {archiveTarget.first_name}
+                </strong>
+                ?
+              </p>
+              <p>Oznacza to, że:</p>
+              <ul className="list-disc space-y-1 pl-5">
+                <li>Zakończone assignmenty pozostaną w historii.</li>
+                <li>Trwające zostaną skrócone do dzisiaj.</li>
+                <li>Przyszłe zostaną usunięte.</li>
+              </ul>
+              <p>
+                Nie będzie można też przypisać tego pracownika do nowych
+                projektów. Pracownik zniknie z kalendarza pracowników, ale
+                pozostanie widoczny w kalendarzu projektów.
+              </p>
+            </div>
+          ) : (
+            ""
+          )
+        }
+        confirmLabel="Archiwizuj"
+        pendingLabel="Archiwizowanie..."
+        onConfirm={() =>
+          archiveTarget && archiveMutation.mutate(archiveTarget.id)
+        }
+        isPending={archiveMutation.isPending}
+        contentClassName="max-w-md"
+      />
+
+      <ConfirmDialog
         open={crud.deleteTarget !== null}
         onOpenChange={(o) => !o && crud.setDeleteTarget(null)}
         title="Usuń pracownika"
         description={
           crud.deleteTarget ? (
-            <>
-              Czy na pewno chcesz usunąć pracownika{" "}
-              <strong>
-                {crud.deleteTarget.last_name} {crud.deleteTarget.first_name}
-              </strong>
-              ? Przyszłe assignmenty zostaną usunięte, a bieżące skrócone do
-              dzisiaj.
-            </>
+            <div className="space-y-2">
+              <p>
+                Czy na pewno chcesz trwale usunąć pracownika{" "}
+                <strong>
+                  {crud.deleteTarget.last_name} {crud.deleteTarget.first_name}
+                </strong>
+                ? Oznacza to, że znikną też wszystkie assignmenty z nim
+                związane. Jeśli chcesz tylko zakończyć współpracę i zachować
+                historię, zarchiwizuj go zamiast usuwać.
+              </p>
+              <p>
+                <strong>Tej operacji nie da się cofnąć.</strong>
+              </p>
+            </div>
           ) : (
             ""
           )

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import * as React from "react";
+import { Popover as PopoverPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+/**
+ * Portalled popover panel. Radix flips it above the trigger and caps its height
+ * to the free space, so panels near the bottom of the viewport are never clipped.
+ */
+function PopoverContent({
+  className,
+  align = "start",
+  sideOffset = 4,
+  collisionPadding = 8,
+  container,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content> & {
+  /** Portal target; defaults to document.body. See usePopoverContainer(). */
+  container?: HTMLElement | null;
+}) {
+  return (
+    <PopoverPrimitive.Portal container={container ?? undefined}>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2 z-50 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger };

--- a/frontend/src/hooks/usePopoverPanel.ts
+++ b/frontend/src/hooks/usePopoverPanel.ts
@@ -1,0 +1,38 @@
+import { useRef, useState } from "react";
+
+/** Gap kept between the panel and the viewport edge, matching collisionPadding. */
+const EDGE_PADDING = 12;
+
+/**
+ * Positioning helpers shared by the searchable dropdown panels.
+ *
+ * `container`: Radix portals panels to <body> by default. Inside a modal dialog
+ * that places the panel outside the dialog's scroll lock, which swallows wheel
+ * events over the list, and outside its dismissable layer, which makes clicks
+ * elsewhere in the dialog flicker. Portalling into the dialog keeps the panel in
+ * that subtree while Popper still positions it against the viewport.
+ *
+ * `side`: chosen here, from the unfiltered panel height, instead of letting Radix
+ * flip on its own. Radix only flips away from its preferred side when that side
+ * does not fit, so pinning the side we picked stops the panel from jumping from
+ * above the field to below it as search results shrink the list.
+ */
+export function usePopoverPanel() {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+  const [side, setSide] = useState<"top" | "bottom">("bottom");
+
+  /** Call when the panel opens, with its expected unfiltered height in px. */
+  const preparePanel = (panelHeight: number) => {
+    const trigger = triggerRef.current;
+    setContainer(
+      trigger?.closest<HTMLElement>('[data-slot="dialog-content"]') ?? null,
+    );
+    if (!trigger) return;
+    const spaceBelow =
+      window.innerHeight - trigger.getBoundingClientRect().bottom - EDGE_PADDING;
+    setSide(spaceBelow >= panelHeight ? "bottom" : "top");
+  };
+
+  return { triggerRef, container, side, preparePanel };
+}

--- a/frontend/src/hooks/usePopoverPanel.ts
+++ b/frontend/src/hooks/usePopoverPanel.ts
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 
-/** Gap kept between the panel and the viewport edge, matching collisionPadding. */
+/** Gap kept between the panel and the viewport edge when picking which side
+ * to open on (slightly larger than Radix's collisionPadding of 8). */
 const EDGE_PADDING = 12;
 
 /**

--- a/frontend/src/lib/normalizeForSearch.ts
+++ b/frontend/src/lib/normalizeForSearch.ts
@@ -1,0 +1,13 @@
+/**
+ * Lowercase and strip diacritics so typing without Polish characters still
+ * matches: "krol" finds "Król", "swiatek" finds "Świątek". NFD decomposition
+ * covers accented letters; ł is a standalone letter in Unicode, so it needs
+ * its own mapping.
+ */
+export function normalizeForSearch(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/ł/g, "l");
+}

--- a/frontend/src/types/assignment.ts
+++ b/frontend/src/types/assignment.ts
@@ -82,6 +82,8 @@ export interface AssignmentEmployeeOption {
   id: number;
   last_name: string;
   first_name: string;
+  /** Only ever true for the employee already on the assignment being edited. */
+  is_archived?: boolean;
 }
 
 export interface AssignmentProjectOption {

--- a/frontend/src/types/employee.ts
+++ b/frontend/src/types/employee.ts
@@ -8,7 +8,7 @@ export interface Employee {
   team: Team | null;
   technologies: Technology[];
   email: string | null;
-  is_deleted: boolean;
+  is_archived: boolean;
   created_at: string;
 }
 


### PR DESCRIPTION
Stacked on #79 — merge that one first. The archived-employee marker in this PR relies on a commit from that branch.

## What changes for the user

Three dropdowns that hold long lists now open a panel with a search box, the same way the technology field already worked, but for a single choice:

- **Assignment form** — Pracownik and Projekt
- **Employee form** — Zespół

Typing filters the list, arrows move the highlight, Enter picks the entry, Escape closes the panel. Opening a field scrolls the list to the currently selected entry. Everything the fields showed before is kept: the `— Nieprzypisane (placeholder) —` option, the project colour dot, and the `(zarchiwizowany)` marker on the person already assigned to the edited assignment.

Selects with a handful of options (user role, allocation type) are untouched, since a search box there would only add noise.

## Panels no longer get cut off

All of these panels, the technology multiselect included, are now popovers rendered outside the form. A field low in the window opens its list upwards instead of running past the window edge, the list height adapts to the free space, and the panel keeps its chosen side while search results narrow it down, so it does not jump around mid-search.

## Notes for review

- `SearchableSelect` is the new shared single-choice field; `MultiSelectField` was moved onto the same popover foundation and keeps its API.
- Field labels are tied to these fields with `aria-labelledby` rather than `htmlFor`, because a label click is forwarded to its control and would reopen a panel that the same click just closed.
- Verified in the browser across both dialogs: opening, filtering, keyboard picking, wheel scrolling in a long list, panel placement near the window edge, and clicks elsewhere in the dialog closing the panel without disturbing the dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)