### PR TITLE
feat: manage part-time capacity as effective-dated periods

### DIFF
--- a/backend/alembic/versions/p6e7f8a9b0c1_employee_capacity_periods.py
+++ b/backend/alembic/versions/p6e7f8a9b0c1_employee_capacity_periods.py
@@ -1,0 +1,92 @@
+"""employee_capacity_periods
+
+Introduce part-time capacity as effective-dated slices instead of a single
+column on `employees`, so changing someone's contract from a given month does
+not rewrite occupancy for the months before it.
+
+Each row carries a start date only; it stays in force until the next row
+begins. That keeps the timeline gap-free and makes overlaps impossible, at the
+cost of one deliberate asymmetry: days *before* an employee's earliest row are
+uncovered and count as zero availability, which is how "not employed yet" is
+expressed.
+
+Every existing employee is backfilled with a single row starting 1900-01-01 at
+100%, i.e. the behaviour hard-coded until now. Nobody becomes retroactively
+part-time or retroactively unemployed by running this migration.
+
+Revision ID: p6e7f8a9b0c1
+Revises: o5d6e7f8a9b0
+Create Date: 2026-08-07 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'p6e7f8a9b0c1'
+down_revision: Union[str, Sequence[str], None] = 'o5d6e7f8a9b0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    sa.Enum("percentage", "monthly_hours", name="capacitytype").create(
+        op.get_bind(), checkfirst=True
+    )
+    # create_type=False: the type is created above, so leave create_table to
+    # reference it rather than emitting a second CREATE TYPE.
+    capacity_type = postgresql.ENUM(
+        "percentage", "monthly_hours", name="capacitytype", create_type=False
+    )
+
+    op.create_table(
+        "employee_capacities",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("employee_id", sa.Integer(), nullable=False),
+        sa.Column("valid_from", sa.Date(), nullable=False),
+        sa.Column("capacity_type", capacity_type, nullable=False),
+        sa.Column("capacity_value", sa.Numeric(7, 2), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(
+            ["employee_id"], ["employees.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "employee_id", "valid_from", name="uq_capacity_employee_from"
+        ),
+    )
+    op.create_index(
+        "ix_employee_capacities_employee_id",
+        "employee_capacities",
+        ["employee_id"],
+    )
+
+    # Backfill: preserve today's behaviour (everyone full time, from always).
+    op.execute(
+        """
+        INSERT INTO employee_capacities
+            (employee_id, valid_from, capacity_type, capacity_value)
+        SELECT id, DATE '1900-01-01', 'percentage', 100.00
+        FROM employees
+        """
+    )
+
+
+def downgrade() -> None:
+    # Dropping the table returns everyone to an implicit full-time contract.
+    # Part-time settings entered after the upgrade cannot be represented in the
+    # old schema and are lost.
+    op.drop_index(
+        "ix_employee_capacities_employee_id", table_name="employee_capacities"
+    )
+    op.drop_table("employee_capacities")
+    sa.Enum(name="capacitytype").drop(op.get_bind(), checkfirst=True)

--- a/backend/app/api/assignments.py
+++ b/backend/app/api/assignments.py
@@ -100,7 +100,7 @@ async def create_assignment(
         )
         employee = emp.scalar_one_or_none()
         if not employee:
-            raise HTTPException(status_code=404, detail="Employee not found")
+            raise HTTPException(status_code=404, detail="Nie znaleziono pracownika")
         if employee.is_archived:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -111,7 +111,7 @@ async def create_assignment(
     proj = await db.execute(select(Project).where(Project.id == body.project_id))
     project = proj.scalar_one_or_none()
     if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+        raise HTTPException(status_code=404, detail="Nie znaleziono projektu")
     if project.is_archived:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -144,7 +144,7 @@ async def update_assignment(
     result = await db.execute(select(Assignment).where(Assignment.id == assignment_id))
     assignment = result.scalar_one_or_none()
     if not assignment:
-        raise HTTPException(status_code=404, detail="Assignment not found")
+        raise HTTPException(status_code=404, detail="Nie znaleziono assignmentu")
 
     if "employee_id" in body.model_fields_set:
         if body.employee_id is None:
@@ -156,7 +156,7 @@ async def update_assignment(
             )
             employee = emp.scalar_one_or_none()
             if not employee:
-                raise HTTPException(status_code=404, detail="Employee not found")
+                raise HTTPException(status_code=404, detail="Nie znaleziono pracownika")
             if employee.is_archived:
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
@@ -168,7 +168,7 @@ async def update_assignment(
         proj = await db.execute(select(Project).where(Project.id == body.project_id))
         project = proj.scalar_one_or_none()
         if not project:
-            raise HTTPException(status_code=404, detail="Project not found")
+            raise HTTPException(status_code=404, detail="Nie znaleziono projektu")
         if project.is_archived:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -216,7 +216,7 @@ async def split_assignment(
     result = await db.execute(select(Assignment).where(Assignment.id == assignment_id))
     assignment = result.scalar_one_or_none()
     if not assignment:
-        raise HTTPException(status_code=404, detail="Assignment not found")
+        raise HTTPException(status_code=404, detail="Nie znaleziono assignmentu")
 
     if split_date <= assignment.start_date or split_date > assignment.end_date:
         raise HTTPException(
@@ -267,7 +267,7 @@ async def duplicate_assignment(
     result = await db.execute(select(Assignment).where(Assignment.id == assignment_id))
     assignment = result.scalar_one_or_none()
     if not assignment:
-        raise HTTPException(status_code=404, detail="Assignment not found")
+        raise HTTPException(status_code=404, detail="Nie znaleziono assignmentu")
 
     # Duplicating creates a new assignment, so it is subject to the same guards
     # as create: neither the employee nor the project may be archived.
@@ -278,7 +278,7 @@ async def duplicate_assignment(
         )
         employee = emp.scalar_one_or_none()
         if not employee:
-            raise HTTPException(status_code=404, detail="Employee not found")
+            raise HTTPException(status_code=404, detail="Nie znaleziono pracownika")
         if employee.is_archived:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -290,7 +290,7 @@ async def duplicate_assignment(
     )
     project = proj.scalar_one_or_none()
     if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+        raise HTTPException(status_code=404, detail="Nie znaleziono projektu")
     if project.is_archived:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -322,7 +322,7 @@ async def delete_assignment(
     result = await db.execute(select(Assignment).where(Assignment.id == assignment_id))
     assignment = result.scalar_one_or_none()
     if not assignment:
-        raise HTTPException(status_code=404, detail="Assignment not found")
+        raise HTTPException(status_code=404, detail="Nie znaleziono assignmentu")
 
     await db.delete(assignment)
     await db.commit()

--- a/backend/app/api/calendar.py
+++ b/backend/app/api/calendar.py
@@ -15,6 +15,12 @@ from app.models.employee import Employee, Technology
 from app.models.user import User
 from app.models.vacation import Vacation
 from app.services.assignment_service import calculate_daily_hours
+from app.services.capacity_service import (
+    assignment_base_daily_hours,
+    build_capacity_periods,
+    daily_capacity_hours,
+    serialize_capacity,
+)
 from app.services.vacation_sync_service import (
     get_calamari_config,
     get_default_sync_range,
@@ -28,11 +34,15 @@ from app.utils.working_days import get_working_days, get_working_days_in_month
 router = APIRouter(tags=["calendar"])
 
 
-def _serialize_timeline_assignment(a: Assignment, range_start: date) -> dict:
+def _serialize_timeline_assignment(
+    a: Assignment, range_start: date, capacities: list | None = None
+) -> dict:
     """Serialize an assignment for the timeline response.
 
     daily_hours is computed for the first month of the assignment visible in
     the requested range (assignments starting before the range use range_start).
+    Without capacities — placeholder assignments, which have no assignee — a
+    percentage means a share of a full-time day.
     """
     first_month_date = max(a.start_date, range_start)
     daily = calculate_daily_hours(
@@ -42,6 +52,7 @@ def _serialize_timeline_assignment(a: Assignment, range_start: date) -> dict:
         first_month_date.month,
         start_date=a.start_date,
         end_date=a.end_date,
+        base_daily_hours=assignment_base_daily_hours(capacities, first_month_date),
     )
     return {
         "id": a.id,
@@ -169,8 +180,11 @@ async def get_timeline(
     for emp in employees:
         assignments = assignments_by_employee[emp.id]
 
+        capacities = emp.capacities
+
         assignment_list = [
-            _serialize_timeline_assignment(a, start_date) for a in assignments
+            _serialize_timeline_assignment(a, start_date, capacities)
+            for a in assignments
         ]
 
         # Employee vacations
@@ -192,7 +206,12 @@ async def get_timeline(
             for week_start, week_end in _get_weeks_in_range(start_date, end_date):
                 key = _week_key(week_start)
                 occupancy[key] = _compute_occupancy_for_period(
-                    assignments, emp_vacations, week_start, week_end, holiday_dates,
+                    assignments,
+                    emp_vacations,
+                    week_start,
+                    week_end,
+                    holiday_dates,
+                    capacities,
                 )
         else:
             for y, m in months:
@@ -200,7 +219,12 @@ async def get_timeline(
                 period_start = date(y, m, 1)
                 period_end = date(y, m, cal_mod.monthrange(y, m)[1])
                 occupancy[key] = _compute_occupancy_for_period(
-                    assignments, emp_vacations, period_start, period_end, holiday_dates,
+                    assignments,
+                    emp_vacations,
+                    period_start,
+                    period_end,
+                    holiday_dates,
+                    capacities,
                 )
 
         employee_data.append(
@@ -212,12 +236,20 @@ async def get_timeline(
                 "assignments": assignment_list,
                 "vacations": vacation_list,
                 "occupancy": occupancy,
+                # Run-length encoded contracted hours, so the frontend can size
+                # its own per-day availability figures without re-implementing
+                # the capacity rules.
+                "capacity_periods": build_capacity_periods(
+                    capacities, start_date, end_date
+                ),
+                "capacity": serialize_capacity(emp.current_capacity),
             }
         )
 
-    # Build placeholder (unassigned) assignments list
+    # Placeholder assignments belong to nobody, so percentages fall back to the
+    # full-time norm until the work is given to a person.
     placeholder_list = [
-        _serialize_timeline_assignment(a, start_date)
+        _serialize_timeline_assignment(a, start_date, None)
         for a in placeholder_assignments
     ]
 
@@ -261,16 +293,24 @@ def _compute_occupancy_for_period(
     period_start: date,
     period_end: date,
     holiday_dates: set,
+    capacities: list | None = None,
 ) -> dict:
     """Compute occupancy metrics for a period (week or month).
 
-    Denominator: net_available = (working_days - vacation_days) * 8
+    Denominator: the employee's contracted hours summed over non-vacation
+    working days. That is a full-time day for the full-time majority, and their
+    own shorter day for part-timers, so vacation always removes what the person
+    would actually have worked rather than a flat eight hours.
+
     Numerator:
       - percentage allocations: hours only on non-vacation working days
       - hours-based allocations: full committed hours across all working days
-        (vacation reduces net_available, not the commitment)
+        (vacation reduces the denominator, not the commitment)
+
+    Zero availability with hours booked (work planned before someone joins) is
+    reported as overbooked rather than as 0%, since the ratio is undefined.
     """
-    net_available_days = 0
+    net_available = Decimal("0")
     hours_numerator = Decimal("0")
 
     d = period_start
@@ -282,7 +322,11 @@ def _compute_occupancy_for_period(
         is_vacation = any(v.start_date <= d <= v.end_date for v in vacations)
 
         if not is_vacation:
-            net_available_days += 1
+            net_available += (
+                daily_capacity_hours(capacities, d)
+                if capacities is not None
+                else Decimal("8")
+            )
 
         for a in assignments:
             if not (a.start_date <= d <= a.end_date):
@@ -294,6 +338,7 @@ def _compute_occupancy_for_period(
                 d.month,
                 start_date=a.start_date,
                 end_date=a.end_date,
+                base_daily_hours=assignment_base_daily_hours(capacities, d),
             )
             if a.allocation_type == AllocationType.percentage:
                 if not is_vacation:
@@ -303,18 +348,18 @@ def _compute_occupancy_for_period(
 
         d += timedelta(days=1)
 
-    net_available = Decimal(str(net_available_days)) * Decimal("8")
-
     if net_available == 0:
         pct = 0.0
+        overbooked = hours_numerator > 0
     else:
         pct = float(round(hours_numerator / net_available * Decimal("100"), 1))
+        overbooked = pct > 100
 
     return {
         "percentage": pct,
         "hours": float(round(hours_numerator, 1)),
         "available_hours": float(round(net_available, 1)),
-        "is_overbooked": pct > 100,
+        "is_overbooked": overbooked,
     }
 
 

--- a/backend/app/api/employees.py
+++ b/backend/app/api/employees.py
@@ -8,9 +8,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.dependencies import get_current_user, get_db, require_admin, require_editor
 from app.models.assignment import Assignment
-from app.models.employee import Employee, Team, Technology
+from app.models.employee import CapacityType, Employee, EmployeeCapacity, Team, Technology
 from app.models.user import User
-from app.schemas.employee import EmployeeCreate, EmployeeResponse, EmployeeUpdate
+from app.schemas.employee import (
+    CapacityCreate,
+    CapacityResponse,
+    CapacityUpdate,
+    EmployeeCreate,
+    EmployeeResponse,
+    EmployeeUpdate,
+)
+from app.services.capacity_service import baseline_capacity
 from app.services.lifecycle_service import (
     count_assignments,
     delete_assignments,
@@ -71,6 +79,52 @@ async def _validate_team_id(db: AsyncSession, team_id: Optional[int]) -> None:
     result = await db.execute(select(Team).where(Team.id == team_id))
     if not result.scalar_one_or_none():
         raise HTTPException(status_code=400, detail="Invalid team_id")
+
+
+async def _get_employee(db: AsyncSession, employee_id: int) -> Employee:
+    """Load an employee or raise 404."""
+    result = await db.execute(select(Employee).where(Employee.id == employee_id))
+    employee = result.scalar_one_or_none()
+    if not employee:
+        raise HTTPException(status_code=404, detail="Nie znaleziono pracownika")
+    return employee
+
+
+async def _reload_capacities(
+    db: AsyncSession, employee_id: int
+) -> list[EmployeeCapacity]:
+    """Return an employee's capacity entries, oldest first."""
+    result = await db.execute(
+        select(EmployeeCapacity)
+        .where(EmployeeCapacity.employee_id == employee_id)
+        .order_by(EmployeeCapacity.valid_from)
+    )
+    return list(result.scalars().all())
+
+
+async def _ensure_valid_from_available(
+    db: AsyncSession,
+    employee_id: int,
+    valid_from,
+    exclude_id: Optional[int] = None,
+) -> None:
+    """Reject a second capacity entry starting on the same day.
+
+    Two entries sharing a start date would make the one in force ambiguous, and
+    the database constraint would surface it as a 500.
+    """
+    query = select(EmployeeCapacity).where(
+        EmployeeCapacity.employee_id == employee_id,
+        EmployeeCapacity.valid_from == valid_from,
+    )
+    if exclude_id is not None:
+        query = query.where(EmployeeCapacity.id != exclude_id)
+    result = await db.execute(query)
+    if result.scalars().first():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Okres zaczynający się w tym dniu już istnieje",
+        )
 
 
 @router.get("", response_model=list[EmployeeResponse])
@@ -138,12 +192,17 @@ async def create_employee(
 
     await _ensure_email_available(db, body.email)
 
+    # Start everyone full time from always. New records often describe people
+    # who have been here for years, so their existing assignments must count
+    # from day one; narrowing the first period is how an employment start gets
+    # recorded, and that is a deliberate act.
     employee = Employee(
         first_name=body.first_name,
         last_name=body.last_name,
         team_id=body.team_id,
         email=body.email,
         technologies=technologies,
+        capacities=[baseline_capacity()],
     )
     db.add(employee)
     await db.commit()
@@ -161,7 +220,7 @@ async def update_employee(
     result = await db.execute(select(Employee).where(Employee.id == employee_id))
     employee = result.scalar_one_or_none()
     if not employee:
-        raise HTTPException(status_code=404, detail="Employee not found")
+        raise HTTPException(status_code=404, detail="Nie znaleziono pracownika")
 
     if body.first_name is not None:
         employee.first_name = body.first_name
@@ -197,7 +256,7 @@ async def delete_employee(
     result = await db.execute(select(Employee).where(Employee.id == employee_id))
     employee = result.scalar_one_or_none()
     if not employee:
-        raise HTTPException(status_code=404, detail="Employee not found")
+        raise HTTPException(status_code=404, detail="Nie znaleziono pracownika")
 
     assignment_filter = Assignment.employee_id == employee_id
     assignments_count = await count_assignments(db, assignment_filter)
@@ -218,6 +277,122 @@ async def delete_employee(
     return {"deleted": True, "deleted_assignments": deleted_assignments}
 
 
+@router.get("/{employee_id}/capacities", response_model=list[CapacityResponse])
+async def list_capacities(
+    employee_id: int,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(get_current_user),
+):
+    """List an employee's contracted capacity periods, oldest first.
+
+    Each entry stays in force until the next one starts. Time before the first
+    entry is intentionally uncovered and counts as zero availability.
+    """
+    await _get_employee(db, employee_id)
+    return await _reload_capacities(db, employee_id)
+
+
+@router.post(
+    "/{employee_id}/capacities",
+    response_model=list[CapacityResponse],
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_capacity(
+    employee_id: int,
+    body: CapacityCreate,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_editor),
+):
+    """Add a capacity period, which ends the preceding one automatically.
+
+    Occupancy for the affected months is recomputed on the next timeline read;
+    earlier months keep the capacity that was in force back then.
+    """
+    await _get_employee(db, employee_id)
+    await _ensure_valid_from_available(db, employee_id, body.valid_from)
+
+    db.add(
+        EmployeeCapacity(
+            employee_id=employee_id,
+            valid_from=body.valid_from,
+            capacity_type=CapacityType(body.capacity_type),
+            capacity_value=body.capacity_value,
+        )
+    )
+    await db.commit()
+    return await _reload_capacities(db, employee_id)
+
+
+@router.patch(
+    "/{employee_id}/capacities/{capacity_id}", response_model=list[CapacityResponse]
+)
+async def update_capacity(
+    employee_id: int,
+    capacity_id: int,
+    body: CapacityUpdate,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_editor),
+):
+    """Edit a capacity period, including its start date.
+
+    Moving the earliest period's start date is how an employment start is
+    recorded: everything before it becomes uncovered, hence unavailable.
+    """
+    await _get_employee(db, employee_id)
+    result = await db.execute(
+        select(EmployeeCapacity).where(
+            EmployeeCapacity.id == capacity_id,
+            EmployeeCapacity.employee_id == employee_id,
+        )
+    )
+    capacity = result.scalar_one_or_none()
+    if not capacity:
+        raise HTTPException(status_code=404, detail="Nie znaleziono okresu wymiaru etatu")
+
+    await _ensure_valid_from_available(
+        db, employee_id, body.valid_from, exclude_id=capacity_id
+    )
+
+    capacity.valid_from = body.valid_from
+    capacity.capacity_type = CapacityType(body.capacity_type)
+    capacity.capacity_value = body.capacity_value
+
+    await db.commit()
+    return await _reload_capacities(db, employee_id)
+
+
+@router.delete(
+    "/{employee_id}/capacities/{capacity_id}", response_model=list[CapacityResponse]
+)
+async def delete_capacity(
+    employee_id: int,
+    capacity_id: int,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_editor),
+):
+    """Remove a capacity period; the preceding one extends over the gap.
+
+    The last remaining period cannot be removed — an employee with no periods
+    at all would have zero availability for all time, which no occupancy figure
+    could express meaningfully.
+    """
+    await _get_employee(db, employee_id)
+    capacities = await _reload_capacities(db, employee_id)
+
+    target = next((c for c in capacities if c.id == capacity_id), None)
+    if not target:
+        raise HTTPException(status_code=404, detail="Nie znaleziono okresu wymiaru etatu")
+    if len(capacities) == 1:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Nie można usunąć jedynego okresu wymiaru etatu",
+        )
+
+    await db.delete(target)
+    await db.commit()
+    return await _reload_capacities(db, employee_id)
+
+
 @router.post("/{employee_id}/archive", response_model=EmployeeResponse)
 async def archive_employee(
     employee_id: int,
@@ -233,7 +408,7 @@ async def archive_employee(
     result = await db.execute(select(Employee).where(Employee.id == employee_id))
     employee = result.scalar_one_or_none()
     if not employee:
-        raise HTTPException(status_code=404, detail="Employee not found")
+        raise HTTPException(status_code=404, detail="Nie znaleziono pracownika")
 
     employee.is_archived = True
     await wind_down_assignments(db, Assignment.employee_id == employee_id)
@@ -257,7 +432,7 @@ async def unarchive_employee(
     result = await db.execute(select(Employee).where(Employee.id == employee_id))
     employee = result.scalar_one_or_none()
     if not employee:
-        raise HTTPException(status_code=404, detail="Employee not found")
+        raise HTTPException(status_code=404, detail="Nie znaleziono pracownika")
 
     employee.is_archived = False
     await db.commit()

--- a/backend/app/api/project_timeline.py
+++ b/backend/app/api/project_timeline.py
@@ -13,6 +13,7 @@ from app.models.employee import Employee
 from app.models.project import Project
 from app.models.user import User
 from app.services.assignment_service import calculate_daily_hours
+from app.services.capacity_service import assignment_base_daily_hours
 from app.utils.polish_holidays import get_holiday_name, get_polish_holidays
 from app.utils.working_days import get_working_days_in_month
 
@@ -88,6 +89,10 @@ async def get_project_timeline(
         assignment_list = []
         for a in assignments_by_project[proj.id]:
             first_month_date = max(a.start_date, start_date)
+            emp = a.employee
+            # A percentage is a share of the assignee's own time, so the same
+            # 50% is fewer hours for a part-timer. Placeholders have no
+            # assignee and fall back to the full-time norm.
             daily = calculate_daily_hours(
                 a.allocation_type.value,
                 a.allocation_value,
@@ -95,8 +100,10 @@ async def get_project_timeline(
                 first_month_date.month,
                 start_date=a.start_date,
                 end_date=a.end_date,
+                base_daily_hours=assignment_base_daily_hours(
+                    emp.capacities if emp else None, first_month_date
+                ),
             )
-            emp = a.employee
             assignment_list.append(
                 {
                     "id": a.id,

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -74,7 +74,7 @@ async def update_project(
     result = await db.execute(select(Project).where(Project.id == project_id))
     project = result.scalar_one_or_none()
     if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+        raise HTTPException(status_code=404, detail="Nie znaleziono projektu")
 
     if body.name is not None:
         # Check unique name (case-insensitive, excluding self)
@@ -115,7 +115,7 @@ async def delete_project(
     result = await db.execute(select(Project).where(Project.id == project_id))
     project = result.scalar_one_or_none()
     if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+        raise HTTPException(status_code=404, detail="Nie znaleziono projektu")
 
     assignment_filter = Assignment.project_id == project_id
     assignments_count = await count_assignments(db, assignment_filter)
@@ -151,7 +151,7 @@ async def archive_project(
     result = await db.execute(select(Project).where(Project.id == project_id))
     project = result.scalar_one_or_none()
     if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+        raise HTTPException(status_code=404, detail="Nie znaleziono projektu")
 
     project.is_archived = True
     await wind_down_assignments(db, Assignment.project_id == project_id)
@@ -175,7 +175,7 @@ async def unarchive_project(
     result = await db.execute(select(Project).where(Project.id == project_id))
     project = result.scalar_one_or_none()
     if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+        raise HTTPException(status_code=404, detail="Nie znaleziono projektu")
 
     project.is_archived = False
     await db.commit()

--- a/backend/app/api/teams.py
+++ b/backend/app/api/teams.py
@@ -54,7 +54,7 @@ async def update_team(
     result = await db.execute(select(Team).where(Team.id == team_id))
     team = result.scalar_one_or_none()
     if not team:
-        raise HTTPException(status_code=404, detail="Team not found")
+        raise HTTPException(status_code=404, detail="Nie znaleziono zespołu")
 
     existing = await db.execute(
         select(Team).where(
@@ -83,7 +83,7 @@ async def delete_team(
     result = await db.execute(select(Team).where(Team.id == team_id))
     team = result.scalar_one_or_none()
     if not team:
-        raise HTTPException(status_code=404, detail="Team not found")
+        raise HTTPException(status_code=404, detail="Nie znaleziono zespołu")
 
     # Hard delete: detach the team from any employees, then remove it entirely.
     await db.execute(

--- a/backend/app/api/technologies.py
+++ b/backend/app/api/technologies.py
@@ -62,7 +62,7 @@ async def update_technology(
     )
     technology = result.scalar_one_or_none()
     if not technology:
-        raise HTTPException(status_code=404, detail="Technology not found")
+        raise HTTPException(status_code=404, detail="Nie znaleziono technologii")
 
     existing = await db.execute(
         select(Technology).where(
@@ -93,7 +93,7 @@ async def delete_technology(
     )
     technology = result.scalar_one_or_none()
     if not technology:
-        raise HTTPException(status_code=404, detail="Technology not found")
+        raise HTTPException(status_code=404, detail="Nie znaleziono technologii")
 
     # Hard delete: removing the row cascades to employee_technologies
     # (ON DELETE CASCADE), so the tag disappears from every employee.

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,12 @@
 from app.models.user import User
-from app.models.employee import Employee, Team, Technology, employee_technologies
+from app.models.employee import (
+    CapacityType,
+    Employee,
+    EmployeeCapacity,
+    Team,
+    Technology,
+    employee_technologies,
+)
 from app.models.project import Project
 from app.models.assignment import Assignment
 from app.models.vacation import Vacation
@@ -7,7 +14,9 @@ from app.models.app_settings import AppSettings
 
 __all__ = [
     "User",
+    "CapacityType",
     "Employee",
+    "EmployeeCapacity",
     "Team",
     "Technology",
     "employee_technologies",

--- a/backend/app/models/employee.py
+++ b/backend/app/models/employee.py
@@ -1,16 +1,22 @@
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Optional
+import enum
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Optional, Sequence
 
 from sqlalchemy import (
     Boolean,
     Column,
+    Date,
     DateTime,
+    Enum,
     ForeignKey,
     Integer,
+    Numeric,
     String,
     Table,
+    UniqueConstraint,
     func,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -81,3 +87,87 @@ class Employee(Base):
         lazy="selectin",
         order_by="Technology.name",
     )
+    capacities: Mapped[list["EmployeeCapacity"]] = relationship(
+        "EmployeeCapacity",
+        lazy="selectin",
+        cascade="all, delete-orphan",
+        order_by="EmployeeCapacity.valid_from",
+        back_populates="employee",
+    )
+
+    @property
+    def current_capacity(self) -> Optional["EmployeeCapacity"]:
+        """The capacity entry in force today, or None if not employed today."""
+        return resolve_capacity_at(self.capacities, date.today())
+
+
+class CapacityType(str, enum.Enum):
+    """How an employee's contracted capacity is expressed.
+
+    Mirrors AllocationType (minus `total_hours`, which is meaningless for an
+    open-ended contract), so both share `calculate_daily_hours`.
+    """
+
+    percentage = "percentage"
+    monthly_hours = "monthly_hours"
+
+
+class EmployeeCapacity(Base):
+    """One effective-dated slice of an employee's contracted capacity.
+
+    Slices carry a start date only: an entry stays in force until the next one
+    begins, so the timeline is always gap-free and no two entries can overlap.
+    A day *before* the earliest entry is deliberately left uncovered and counts
+    as zero availability, which is how "not employed yet" is expressed.
+    """
+
+    __tablename__ = "employee_capacities"
+    __table_args__ = (
+        UniqueConstraint("employee_id", "valid_from", name="uq_capacity_employee_from"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    employee_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("employees.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    valid_from: Mapped[date] = mapped_column(Date, nullable=False)
+    capacity_type: Mapped[CapacityType] = mapped_column(
+        Enum(CapacityType, name="capacitytype"), nullable=False
+    )
+    capacity_value: Mapped[Decimal] = mapped_column(Numeric(7, 2), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    employee: Mapped[Employee] = relationship("Employee", back_populates="capacities")
+
+    @property
+    def is_full_time(self) -> bool:
+        """Whether this entry is an ordinary full-time contract.
+
+        Drives whether the UI marks the employee at all: the badge earns its
+        place precisely because part time is the exception.
+        """
+        return (
+            self.capacity_type == CapacityType.percentage
+            and Decimal(str(self.capacity_value)) == Decimal("100")
+        )
+
+
+def resolve_capacity_at(
+    capacities: Sequence[EmployeeCapacity], day: date
+) -> Optional[EmployeeCapacity]:
+    """Return the capacity entry in force on `day`, or None if none covers it.
+
+    The entry in force is the latest one starting on or before `day`. None means
+    the day precedes the employee's first entry, i.e. zero availability.
+    """
+    in_force = None
+    for capacity in sorted(capacities, key=lambda c: c.valid_from):
+        if capacity.valid_from > day:
+            break
+        in_force = capacity
+    return in_force

--- a/backend/app/schemas/employee.py
+++ b/backend/app/schemas/employee.py
@@ -1,12 +1,55 @@
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Optional
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Literal, Optional
 
 from pydantic import BaseModel, field_validator
 
 from app.schemas.team import TeamResponse
 from app.schemas.technology import TechnologyResponse
+
+CapacityTypeLiteral = Literal["percentage", "monthly_hours"]
+
+
+class CapacityBase(BaseModel):
+    valid_from: date
+    capacity_type: CapacityTypeLiteral
+    capacity_value: float
+
+    @field_validator("capacity_type", mode="before")
+    @classmethod
+    def enum_to_value(cls, v: object) -> object:
+        """Accept the SQLAlchemy enum as well as its wire value."""
+        return v.value if hasattr(v, "value") else v
+
+    @field_validator("capacity_value")
+    @classmethod
+    def value_must_be_positive(cls, v: float) -> float:
+        """Zero capacity is expressed by the absence of an entry, not by 0.
+
+        Leaving a stretch of time uncovered is what marks somebody as not
+        employed yet; an entry worth nothing would be a second way to say the
+        same thing, and one that silently swallows any work booked against it.
+        """
+        if v <= 0:
+            raise ValueError("must be greater than 0")
+        return round(v, 2)
+
+
+class CapacityCreate(CapacityBase):
+    pass
+
+
+class CapacityUpdate(CapacityBase):
+    pass
+
+
+class CapacityResponse(CapacityBase):
+    id: int
+    is_full_time: bool
+
+    model_config = {"from_attributes": True}
 
 
 class EmployeeCreate(BaseModel):
@@ -48,5 +91,9 @@ class EmployeeResponse(BaseModel):
     email: Optional[str] = None
     is_archived: bool
     created_at: datetime
+    capacities: list[CapacityResponse] = []
+    # None means no contract covers today, i.e. the employee has not started yet
+    # (or their entries end before today).
+    current_capacity: Optional[CapacityResponse] = None
 
     model_config = {"from_attributes": True}

--- a/backend/app/schemas/employee.py
+++ b/backend/app/schemas/employee.py
@@ -4,7 +4,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from typing import Literal, Optional
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, model_validator
 
 from app.schemas.team import TeamResponse
 from app.schemas.technology import TechnologyResponse
@@ -35,6 +35,17 @@ class CapacityBase(BaseModel):
         if v <= 0:
             raise ValueError("must be greater than 0")
         return round(v, 2)
+
+    @model_validator(mode="after")
+    def value_within_type_bounds(self) -> "CapacityBase":
+        """Catch order-of-magnitude typos: capacity scales the occupancy
+        denominator for every assignment the person has, so a stray zero
+        distorts the whole timeline, not one entry."""
+        if self.capacity_type == "percentage" and self.capacity_value > 100:
+            raise ValueError("percentage capacity cannot exceed 100")
+        if self.capacity_type == "monthly_hours" and self.capacity_value > 744:
+            raise ValueError("monthly hours cannot exceed 744")
+        return self
 
 
 class CapacityCreate(CapacityBase):

--- a/backend/app/services/assignment_service.py
+++ b/backend/app/services/assignment_service.py
@@ -7,6 +7,9 @@ from app.models.assignment import AllocationType
 from app.utils.working_days import get_working_days, get_working_days_in_month
 
 
+FULL_TIME_DAILY_HOURS = Decimal("8")
+
+
 def calculate_daily_hours(
     allocation_type: str,
     allocation_value: Decimal | float,
@@ -14,19 +17,24 @@ def calculate_daily_hours(
     month: int,
     start_date: date | None = None,
     end_date: date | None = None,
+    base_daily_hours: Decimal | float = FULL_TIME_DAILY_HOURS,
 ) -> Decimal:
     """Calculate daily hours for an assignment in a given month.
 
-    For percentage: daily_hours = 8 * (allocation_value / 100)
+    For percentage: daily_hours = base_daily_hours * (allocation_value / 100)
     For monthly_hours: daily_hours = allocation_value / working_days_in_month
     For total_hours: daily_hours = allocation_value / working_days(start_date, end_date)
+
+    `base_daily_hours` is what 100% means for this assignment: a full-time day
+    by default, or the employee's contracted daily hours when they work part
+    time. Hours-based allocations are absolute and ignore it.
     """
     value = Decimal(str(allocation_value))
     if (
         allocation_type == AllocationType.percentage.value
         or allocation_type == AllocationType.percentage
     ):
-        return Decimal("8") * (value / Decimal("100"))
+        return Decimal(str(base_daily_hours)) * (value / Decimal("100"))
 
     if (
         allocation_type == AllocationType.total_hours.value

--- a/backend/app/services/capacity_service.py
+++ b/backend/app/services/capacity_service.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Sequence
+
+from app.models.employee import CapacityType, EmployeeCapacity, resolve_capacity_at
+from app.services.assignment_service import FULL_TIME_DAILY_HOURS, calculate_daily_hours
+
+# The capacity every employee gets on migration and on creation: full time,
+# from always. Narrowing it is a deliberate act (it marks an employment start).
+BASELINE_VALID_FROM = date(1900, 1, 1)
+
+NO_CAPACITY = Decimal("0")
+
+
+def daily_capacity_hours(
+    capacities: Sequence[EmployeeCapacity], day: date
+) -> Decimal:
+    """Hours the employee is contracted for on a working day in `day`'s month.
+
+    Zero when no capacity entry covers the day, which means the employee is not
+    employed then. Monthly-hours contracts spread over that month's working
+    days, so the figure varies month to month; percentage contracts do not.
+    """
+    capacity = resolve_capacity_at(capacities, day)
+    if capacity is None:
+        return NO_CAPACITY
+    return calculate_daily_hours(
+        capacity.capacity_type.value,
+        capacity.capacity_value,
+        day.year,
+        day.month,
+    )
+
+
+def assignment_base_daily_hours(
+    capacities: Sequence[EmployeeCapacity] | None, day: date
+) -> Decimal:
+    """What 100% means for an assignment on `day`.
+
+    A percentage is a share of the person's own time, so it scales with their
+    contract. Two deliberate fallbacks to the full-time norm: placeholder
+    assignments have nobody to scale to (`capacities` is None), and days outside
+    any contract would otherwise make a percentage worth zero hours, silently
+    hiding work planned before someone joins. Keeping those hours visible lets
+    the period show up as overbooked against zero availability instead.
+    """
+    if capacities is None:
+        return FULL_TIME_DAILY_HOURS
+    hours = daily_capacity_hours(capacities, day)
+    return hours if hours > 0 else FULL_TIME_DAILY_HOURS
+
+
+def build_capacity_periods(
+    capacities: Sequence[EmployeeCapacity], start_date: date, end_date: date
+) -> list[dict]:
+    """Flatten capacity into runs of constant daily hours across a date range.
+
+    The frontend needs per-day capacity to size its own availability figures,
+    but sending one entry per day would be wasteful and sending one per month
+    would be wrong when a contract starts mid-month. Run-length encoding is
+    exact and collapses to a single entry for the full-time majority.
+
+    Returns entries ordered by date, each `{"from": iso_date, "daily_hours":
+    float}`, in force until the next entry starts.
+    """
+    periods: list[dict] = []
+    day = start_date
+    while day <= end_date:
+        hours = float(round(daily_capacity_hours(capacities, day), 2))
+        if not periods or periods[-1]["daily_hours"] != hours:
+            periods.append({"from": day.isoformat(), "daily_hours": hours})
+        day += timedelta(days=1)
+    return periods
+
+
+def serialize_capacity(capacity: EmployeeCapacity | None) -> dict | None:
+    """Serialize one capacity entry for API responses."""
+    if capacity is None:
+        return None
+    return {
+        "id": capacity.id,
+        "valid_from": capacity.valid_from.isoformat(),
+        "capacity_type": capacity.capacity_type.value,
+        "capacity_value": float(capacity.capacity_value),
+        "is_full_time": capacity.is_full_time,
+    }
+
+
+def baseline_capacity(employee_id: int | None = None) -> EmployeeCapacity:
+    """A full-time-from-always entry, used for new employees."""
+    return EmployeeCapacity(
+        employee_id=employee_id,
+        valid_from=BASELINE_VALID_FROM,
+        capacity_type=CapacityType.percentage,
+        capacity_value=Decimal("100"),
+    )
+
+
+__all__ = [
+    "BASELINE_VALID_FROM",
+    "FULL_TIME_DAILY_HOURS",
+    "assignment_base_daily_hours",
+    "baseline_capacity",
+    "build_capacity_periods",
+    "daily_capacity_hours",
+    "serialize_capacity",
+]

--- a/backend/tests/test_capacity.py
+++ b/backend/tests/test_capacity.py
@@ -1,0 +1,309 @@
+"""Unit tests for part-time capacity: resolution, availability and occupancy.
+
+Fixed dates used below:
+- March 2026 has 22 working days (no Polish holidays fall on a weekday).
+- Week Mon 2026-03-02 .. Sun 2026-03-08 -> 5 working days.
+"""
+
+from datetime import date
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from app.api.calendar import _compute_occupancy_for_period
+from app.models.assignment import AllocationType
+from app.models.employee import CapacityType, resolve_capacity_at
+from app.services.capacity_service import (
+    assignment_base_daily_hours,
+    build_capacity_periods,
+    daily_capacity_hours,
+)
+from app.utils.working_days import get_working_days_in_month
+
+WEEK_START = date(2026, 3, 2)  # Monday
+WEEK_END = date(2026, 3, 8)  # Sunday
+MARCH_START = date(2026, 3, 1)
+MARCH_END = date(2026, 3, 31)
+
+
+def make_capacity(valid_from, capacity_type, value):
+    return SimpleNamespace(
+        valid_from=valid_from,
+        capacity_type=capacity_type,
+        capacity_value=Decimal(str(value)),
+    )
+
+
+def make_assignment(start, end, allocation_type, value):
+    return SimpleNamespace(
+        start_date=start,
+        end_date=end,
+        allocation_type=allocation_type,
+        allocation_value=value,
+    )
+
+
+def make_vacation(start, end):
+    return SimpleNamespace(start_date=start, end_date=end)
+
+
+FULL_TIME = [make_capacity(date(1900, 1, 1), CapacityType.percentage, 100)]
+HALF_TIME = [make_capacity(date(1900, 1, 1), CapacityType.percentage, 50)]
+FORTY_HOURS = [make_capacity(date(1900, 1, 1), CapacityType.monthly_hours, 40)]
+
+
+# --- resolve_capacity_at ---
+
+
+def test_latest_entry_on_or_before_the_day_wins():
+    entries = [
+        make_capacity(date(1900, 1, 1), CapacityType.percentage, 100),
+        make_capacity(date(2026, 3, 1), CapacityType.monthly_hours, 40),
+        make_capacity(date(2026, 10, 1), CapacityType.percentage, 100),
+    ]
+
+    assert resolve_capacity_at(entries, date(2026, 2, 28)).capacity_value == 100
+    assert resolve_capacity_at(entries, date(2026, 3, 1)).capacity_value == 40
+    assert resolve_capacity_at(entries, date(2026, 9, 30)).capacity_value == 40
+    # Returning to full time is just another entry, not a special case.
+    assert resolve_capacity_at(entries, date(2026, 10, 1)).capacity_type == (
+        CapacityType.percentage
+    )
+
+
+def test_unordered_entries_resolve_the_same():
+    entries = [
+        make_capacity(date(2026, 3, 1), CapacityType.monthly_hours, 40),
+        make_capacity(date(1900, 1, 1), CapacityType.percentage, 100),
+    ]
+    assert resolve_capacity_at(entries, date(2026, 5, 1)).capacity_value == 40
+
+
+def test_day_before_first_entry_is_uncovered():
+    """No entry covering the day means not employed yet, not full time."""
+    entries = [make_capacity(date(2026, 3, 1), CapacityType.percentage, 100)]
+
+    assert resolve_capacity_at(entries, date(2026, 2, 28)) is None
+    assert daily_capacity_hours(entries, date(2026, 2, 28)) == 0
+
+
+# --- daily_capacity_hours ---
+
+
+def test_percentage_capacity_is_a_fixed_share_of_a_full_day():
+    assert daily_capacity_hours(FULL_TIME, date(2026, 3, 10)) == Decimal("8")
+    assert daily_capacity_hours(HALF_TIME, date(2026, 3, 10)) == Decimal("4")
+
+
+def test_monthly_hours_capacity_spreads_over_that_month_working_days():
+    """40h/month is a different contract from 25%: the daily figure moves with
+    the calendar so the monthly total stays at 40."""
+    march_days = get_working_days_in_month(2026, 3)
+    february_days = get_working_days_in_month(2026, 2)
+    assert march_days != february_days  # guards the point of this test
+
+    march = daily_capacity_hours(FORTY_HOURS, date(2026, 3, 10))
+    february = daily_capacity_hours(FORTY_HOURS, date(2026, 2, 10))
+
+    assert march == Decimal("40") / Decimal(str(march_days))
+    assert february == Decimal("40") / Decimal(str(february_days))
+    assert march != february
+
+
+# --- occupancy denominator ---
+
+
+def test_part_timer_full_commitment_reads_as_one_hundred_percent():
+    """The headline case: 40h booked for someone contracted for 40h/month is a
+    full plate, not a quarter of one."""
+    a = make_assignment(
+        MARCH_START, MARCH_END, AllocationType.monthly_hours, 40.0
+    )
+    result = _compute_occupancy_for_period(
+        [a], [], MARCH_START, MARCH_END, set(), FORTY_HOURS
+    )
+
+    assert result["percentage"] == 100.0
+    assert result["hours"] == 40.0
+    assert result["available_hours"] == 40.0
+    assert result["is_overbooked"] is False
+
+
+def test_same_assignment_against_a_full_time_contract():
+    """Same 40h, full-time contract: the old behaviour, unchanged."""
+    a = make_assignment(
+        MARCH_START, MARCH_END, AllocationType.monthly_hours, 40.0
+    )
+    result = _compute_occupancy_for_period(
+        [a], [], MARCH_START, MARCH_END, set(), FULL_TIME
+    )
+
+    march_hours = get_working_days_in_month(2026, 3) * 8
+    assert result["available_hours"] == float(march_hours)
+    assert result["percentage"] == round(40 / march_hours * 100, 1)
+
+
+def test_percentage_allocation_is_a_share_of_the_persons_own_time():
+    """100% of a half-timer is 4h/day and reads as 100%, not 50%."""
+    a = make_assignment(WEEK_START, WEEK_END, AllocationType.percentage, 100.0)
+    result = _compute_occupancy_for_period(
+        [a], [], WEEK_START, WEEK_END, set(), HALF_TIME
+    )
+
+    assert result["percentage"] == 100.0
+    assert result["hours"] == 20.0  # 5 wd * 4h
+    assert result["available_hours"] == 20.0
+
+
+def test_vacation_removes_the_part_timers_own_day_not_eight_hours():
+    """A half-timer's vacation day costs 4h of availability, so the percentage
+    is unchanged rather than distorted."""
+    a = make_assignment(WEEK_START, WEEK_END, AllocationType.percentage, 100.0)
+    vac = make_vacation(date(2026, 3, 2), date(2026, 3, 3))  # Mon-Tue
+
+    result = _compute_occupancy_for_period(
+        [a], [vac], WEEK_START, WEEK_END, set(), HALF_TIME
+    )
+
+    assert result["available_hours"] == 12.0  # 3 wd * 4h
+    assert result["hours"] == 12.0
+    assert result["percentage"] == 100.0
+
+
+def test_hours_commitment_over_a_part_timer_vacation_overbooks():
+    a = make_assignment(
+        date(2026, 3, 2), date(2026, 3, 6), AllocationType.total_hours, 20.0
+    )
+    vac = make_vacation(date(2026, 3, 2), date(2026, 3, 3))  # Mon-Tue
+
+    result = _compute_occupancy_for_period(
+        [a], [vac], WEEK_START, WEEK_END, set(), HALF_TIME
+    )
+
+    assert result["hours"] == 20.0  # commitment untouched
+    assert result["available_hours"] == 12.0  # 3 wd * 4h
+    assert result["is_overbooked"] is True
+
+
+def test_capacity_change_mid_range_only_affects_days_after_it():
+    """The whole point of dated entries: February keeps the old contract."""
+    entries = [
+        make_capacity(date(1900, 1, 1), CapacityType.percentage, 100),
+        make_capacity(date(2026, 3, 1), CapacityType.percentage, 50),
+    ]
+    a = make_assignment(
+        date(2026, 1, 1), date(2026, 12, 31), AllocationType.percentage, 100.0
+    )
+
+    february = _compute_occupancy_for_period(
+        [a], [], date(2026, 2, 1), date(2026, 2, 28), set(), entries
+    )
+    march = _compute_occupancy_for_period(
+        [a], [], MARCH_START, MARCH_END, set(), entries
+    )
+
+    assert february["available_hours"] == get_working_days_in_month(2026, 2) * 8
+    assert march["available_hours"] == get_working_days_in_month(2026, 3) * 4
+    # Both read as 100%, because the commitment scales with the contract.
+    assert february["percentage"] == 100.0
+    assert march["percentage"] == 100.0
+
+
+def test_omitted_capacity_keeps_the_full_time_default():
+    """Callers that pass no capacity (placeholder rows, older call sites) must
+    keep behaving exactly as before."""
+    a = make_assignment(WEEK_START, WEEK_END, AllocationType.percentage, 50.0)
+
+    assert _compute_occupancy_for_period(
+        [a], [], WEEK_START, WEEK_END, set()
+    ) == _compute_occupancy_for_period(
+        [a], [], WEEK_START, WEEK_END, set(), FULL_TIME
+    )
+
+
+# --- days outside any contract ---
+
+
+def test_work_planned_before_employment_starts_is_flagged_not_hidden():
+    """Availability is zero, so the ratio is undefined; the hours must still
+    show and the period must go red instead of reading as a quiet 0%."""
+    entries = [make_capacity(date(2026, 3, 1), CapacityType.percentage, 100)]
+    a = make_assignment(
+        date(2026, 2, 1), date(2026, 2, 28), AllocationType.percentage, 100.0
+    )
+
+    result = _compute_occupancy_for_period(
+        [a], [], date(2026, 2, 1), date(2026, 2, 28), set(), entries
+    )
+
+    assert result["available_hours"] == 0.0
+    assert result["hours"] > 0
+    assert result["is_overbooked"] is True
+
+
+def test_empty_period_before_employment_is_not_flagged():
+    entries = [make_capacity(date(2026, 3, 1), CapacityType.percentage, 100)]
+
+    result = _compute_occupancy_for_period(
+        [], [], date(2026, 2, 1), date(2026, 2, 28), set(), entries
+    )
+
+    assert result["available_hours"] == 0.0
+    assert result["hours"] == 0.0
+    assert result["is_overbooked"] is False
+
+
+def test_assignment_base_falls_back_to_full_time_outside_any_contract():
+    entries = [make_capacity(date(2026, 3, 1), CapacityType.percentage, 50)]
+
+    assert assignment_base_daily_hours(entries, date(2026, 2, 1)) == Decimal("8")
+    assert assignment_base_daily_hours(entries, date(2026, 3, 1)) == Decimal("4")
+    # Placeholder assignments have nobody to scale to.
+    assert assignment_base_daily_hours(None, date(2026, 3, 1)) == Decimal("8")
+
+
+# --- build_capacity_periods ---
+
+
+def test_full_timer_collapses_to_a_single_period():
+    periods = build_capacity_periods(FULL_TIME, MARCH_START, date(2026, 9, 30))
+
+    assert periods == [{"from": "2026-03-01", "daily_hours": 8.0}]
+
+
+def test_periods_split_where_the_daily_figure_actually_changes():
+    entries = [
+        make_capacity(date(1900, 1, 1), CapacityType.percentage, 100),
+        make_capacity(date(2026, 3, 16), CapacityType.percentage, 50),
+    ]
+    periods = build_capacity_periods(entries, MARCH_START, date(2026, 4, 30))
+
+    assert periods == [
+        {"from": "2026-03-01", "daily_hours": 8.0},
+        {"from": "2026-03-16", "daily_hours": 4.0},
+    ]
+
+
+def test_monthly_hours_periods_split_on_month_boundaries():
+    """A fixed monthly budget means a different daily figure each month, which
+    is exactly why a single month-keyed number would not do."""
+    periods = build_capacity_periods(FORTY_HOURS, MARCH_START, date(2026, 4, 30))
+
+    assert [p["from"] for p in periods] == ["2026-03-01", "2026-04-01"]
+    assert periods[0]["daily_hours"] == pytest.approx(
+        40 / get_working_days_in_month(2026, 3), abs=0.01
+    )
+    assert periods[1]["daily_hours"] == pytest.approx(
+        40 / get_working_days_in_month(2026, 4), abs=0.01
+    )
+
+
+def test_periods_start_with_zero_before_employment():
+    entries = [make_capacity(date(2026, 3, 16), CapacityType.percentage, 100)]
+    periods = build_capacity_periods(entries, MARCH_START, MARCH_END)
+
+    assert periods == [
+        {"from": "2026-03-01", "daily_hours": 0.0},
+        {"from": "2026-03-16", "daily_hours": 8.0},
+    ]

--- a/backend/tests/test_capacity.py
+++ b/backend/tests/test_capacity.py
@@ -307,3 +307,25 @@ def test_periods_start_with_zero_before_employment():
         {"from": "2026-03-01", "daily_hours": 0.0},
         {"from": "2026-03-16", "daily_hours": 8.0},
     ]
+
+
+def test_capacity_value_rejects_values_beyond_type_bounds():
+    from pydantic import ValidationError
+
+    from app.schemas.employee import CapacityCreate
+
+    with pytest.raises(ValidationError):
+        CapacityCreate(
+            valid_from=MARCH_START, capacity_type="percentage", capacity_value=500
+        )
+    with pytest.raises(ValidationError):
+        CapacityCreate(
+            valid_from=MARCH_START, capacity_type="monthly_hours", capacity_value=1600
+        )
+    # Boundary values stay accepted.
+    CapacityCreate(
+        valid_from=MARCH_START, capacity_type="percentage", capacity_value=100
+    )
+    CapacityCreate(
+        valid_from=MARCH_START, capacity_type="monthly_hours", capacity_value=744
+    )

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -32,6 +32,10 @@ PATCH  /api/employees/{id}                  # Update employee (200)
 POST   /api/employees/{id}/archive          # Archive + wind down assignments (200, see below)
 POST   /api/employees/{id}/unarchive        # Re-enable for new assignments (200)
 DELETE /api/employees/{id}                  # Permanent delete with all assignments (200, see below)
+GET    /api/employees/{id}/capacities       # List contracted capacity periods, oldest first
+POST   /api/employees/{id}/capacities       # Add a period (201); 409 if one already starts that day
+PATCH  /api/employees/{id}/capacities/{cid} # Edit a period, start date included
+DELETE /api/employees/{id}/capacities/{cid} # Remove a period; 409 on the last remaining one
 ```
 
 An employee is either **active**, **archived**, or gone. There is no soft-deleted state. The lifecycle mirrors projects exactly; see the Projects section for the wind-down table, which is shared logic.
@@ -41,6 +45,8 @@ An employee is either **active**, **archived**, or gone. There is no soft-delete
 The visibility is deliberately the mirror image of projects: an archived **project** leaves the project timeline and stays in the employee one; an archived **employee** leaves the employee timeline and stays in the project one.
 
 **Unarchive** re-enables the employee for new assignments without restoring what the wind-down removed.
+
+**Capacity periods** carry a start date only; each stays in force until the next one begins, and every mutation returns the employee's full list afterwards. Time before the earliest period is uncovered and means zero availability, which is how an employment start is recorded. See [Data Models](data-models.md) for how capacity feeds occupancy. `EmployeeResponse` also carries `capacities` (the full list) and `current_capacity` (in force today, null when uncovered).
 
 **Delete** is permanent: the employee row and **all** of their assignments. Two-step confirmation — without `?confirm=true`, an employee with any assignments returns:
 
@@ -191,6 +197,16 @@ GET /api/assignments/timeline?start_date=2026-01-01&end_date=2026-06-30&teams=Fr
           "available_hours": 152,
           "is_overbooked": true
         }
+      },
+      "capacity_periods": [
+        { "from": "2026-01-01", "daily_hours": 8.0 }
+      ],
+      "capacity": {
+        "id": 3,
+        "valid_from": "1900-01-01",
+        "capacity_type": "percentage",
+        "capacity_value": 100,
+        "is_full_time": true
       }
     }
   ],
@@ -237,6 +253,8 @@ GET /api/assignments/timeline?start_date=2026-01-01&end_date=2026-06-30&teams=Fr
 | `assignments` | array | Assignments within requested date range |
 | `vacations` | array | Vacations within requested date range |
 | `occupancy` | object | Per-period occupancy keyed by "YYYY-MM" (monthly) or "w-YYYY-WW" (weekly) |
+| `capacity_periods` | array | Contracted hours per working day across the requested range, run-length encoded: `{from, daily_hours}` entries, each in force until the next one. A full-timer collapses to a single entry; `daily_hours: 0` marks time outside employment |
+| `capacity` | object\|null | Capacity in force **today**, for badging. Null when no period covers today |
 
 **Placeholders:**
 
@@ -256,16 +274,16 @@ GET /api/assignments/timeline?start_date=2026-01-01&end_date=2026-06-30&teams=Fr
 | `allocation_value` | decimal | The raw allocation value |
 | `note` | string\|null | Optional note |
 | `is_tentative` | bool | Whether assignment is tentative |
-| `daily_hours` | float | Computed daily hours |
+| `daily_hours` | float | Computed daily hours. For `percentage`, a share of the **assignee's** contracted day, so the same 50% is fewer hours for a part-timer; placeholders use the full-time norm |
 
 **Occupancy object (per period — month or week):**
 
 | Field | Type | Description |
 |---|---|---|
-| `percentage` | float | Allocated hours / net available hours x 100 |
+| `percentage` | float | Allocated hours / net available hours x 100. Always 0 when `available_hours` is 0 |
 | `hours` | float | Total allocated hours in the period |
-| `available_hours` | float | Net available hours: (working days − vacation days) x 8h |
-| `is_overbooked` | bool | True if percentage > 100 |
+| `available_hours` | float | Net available hours: the employee's contracted hours summed over working days minus vacation days. 8h/day for full-timers, less for part-timers, 0 outside employment |
+| `is_overbooked` | bool | True if percentage > 100, **or** if hours are booked against zero availability (work planned before someone joins) |
 
 **Vacation sync status:**
 

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -29,6 +29,21 @@
 | is_archived | Boolean | default false (wind-down state) |
 | created_at | DateTime | auto |
 
+### EmployeeCapacity (contracted capacity, effective-dated)
+
+| Column | Type | Constraints |
+|---|---|---|
+| id | Integer | PK |
+| employee_id | Integer | FK -> Employee, ON DELETE CASCADE, indexed |
+| valid_from | Date | not null, unique together with employee_id |
+| capacity_type | Enum | `percentage` \| `monthly_hours` |
+| capacity_value | Numeric(7,2) | not null, > 0 |
+| created_at | DateTime | auto |
+
+Rows carry a **start date only**: each stays in force until the next one
+begins, so the timeline is gap-free and overlaps are impossible. Returning to
+full time is just another row.
+
 ### Project
 
 | Column | Type | Constraints |
@@ -81,6 +96,7 @@
 ```
 User (standalone — login accounts, not linked to Employee)
 
+Employee  1 ──→ N  EmployeeCapacity  (cascade delete)
 Employee  1 ──→ N  Assignment
 Project   1 ──→ N  Assignment
 
@@ -99,13 +115,50 @@ AppSettings (standalone — stores Calamari config etc.)
 - Working days: Mon-Fri, excluding Polish public holidays
 - Week starts on Monday (ISO standard)
 
+### Contracted Capacity (part time)
+
+Every employee has one or more `EmployeeCapacity` periods. Capacity sets the
+**denominator** of every occupancy figure and the **meaning of 100%** for that
+person.
+
+| Capacity type | Daily hours formula |
+|---|---|
+| Percentage | `8 x (percentage / 100)` — fixed daily hours |
+| Monthly hours | `monthly_hours / working_days_in_month` — fixed monthly total, daily hours move with the calendar |
+
+The two are genuinely different contracts: 25% is always 2h/day (40–46h per
+month), while 40h/month is always 40h (1.7–2.0h/day). Both are offered because
+part-time employment contracts behave like the first and hour-capped B2B
+arrangements like the second.
+
+**Days outside any period count as zero availability**, which is how an
+employment start is recorded: move the earliest period's `valid_from` to the
+joining date and everything before it is uncovered. Consequences:
+
+- A period whose availability is zero but which has hours booked is reported as
+  **overbooked**, not as a quiet 0% — the ratio is undefined and hiding it would
+  hide mis-planned work.
+- Percentage allocations fall back to the full-time norm on uncovered days, so
+  those hours stay visible instead of evaporating to zero.
+- The last remaining period of an employee cannot be deleted.
+
 ### Allocation Calculation
 
 | Type | Daily hours formula |
 |---|---|
-| Percentage | `8 x (percentage / 100)` |
+| Percentage | `base_daily_hours x (percentage / 100)` |
 | Monthly hours | `monthly_hours / working_days_in_month` |
+| Total hours | `total_hours / working_days(start_date, end_date)` |
 | Partial month | Hours proportional to working days in the assignment's overlap with that month |
+
+`base_daily_hours` is the assignee's contracted daily hours, i.e. a full-time
+day for the full-time majority. **A percentage is a share of that person's own
+time**, so 100% means a full plate whether they work 8h or 2h a day. Two
+consequences worth knowing:
+
+- Moving a percentage assignment between employees changes its hours; hours-based
+  allocations are absolute and do not change.
+- Placeholder assignments (no assignee) use the full-time norm.
 
 ### Overbooking
 
@@ -124,7 +177,8 @@ AppSettings (standalone — stores Calamari config etc.)
 ### Vacation Integration
 
 - Vacations synced from Calamari API (manual or scheduled sync)
-- Vacation days reduce net available hours in occupancy calculations
+- Vacation days reduce net available hours in occupancy calculations, by the
+  employee's own contracted hours rather than a flat 8h
 - Percentage allocations skip vacation days entirely; hours-based commitments stay fixed, so vacations can push occupancy above 100%
 
 ### Lifecycle Rules

--- a/frontend/src/api/employees.ts
+++ b/frontend/src/api/employees.ts
@@ -1,5 +1,11 @@
 import { apiFetch } from "./client";
-import type { Employee, EmployeeCreateData, ImportResult } from "@/types/employee";
+import type {
+  CapacityInput,
+  Employee,
+  EmployeeCapacity,
+  EmployeeCreateData,
+  ImportResult,
+} from "@/types/employee";
 import type { DeleteResponse } from "@/types/common";
 
 export function fetchEmployees(
@@ -52,6 +58,46 @@ export function unarchiveEmployee(id: number): Promise<Employee> {
   return apiFetch<Employee>(`/api/employees/${id}/unarchive`, {
     method: "POST",
   });
+}
+
+// Capacity periods are a sub-resource: every call returns the employee's full
+// list afterwards, so the caller never has to merge changes by hand.
+
+export function fetchCapacities(
+  employeeId: number,
+): Promise<EmployeeCapacity[]> {
+  return apiFetch<EmployeeCapacity[]>(`/api/employees/${employeeId}/capacities`);
+}
+
+export function createCapacity(
+  employeeId: number,
+  data: CapacityInput,
+): Promise<EmployeeCapacity[]> {
+  return apiFetch<EmployeeCapacity[]>(
+    `/api/employees/${employeeId}/capacities`,
+    { method: "POST", body: JSON.stringify(data) },
+  );
+}
+
+export function updateCapacity(
+  employeeId: number,
+  capacityId: number,
+  data: CapacityInput,
+): Promise<EmployeeCapacity[]> {
+  return apiFetch<EmployeeCapacity[]>(
+    `/api/employees/${employeeId}/capacities/${capacityId}`,
+    { method: "PATCH", body: JSON.stringify(data) },
+  );
+}
+
+export function deleteCapacity(
+  employeeId: number,
+  capacityId: number,
+): Promise<EmployeeCapacity[]> {
+  return apiFetch<EmployeeCapacity[]>(
+    `/api/employees/${employeeId}/capacities/${capacityId}`,
+    { method: "DELETE" },
+  );
 }
 
 export function importEmployeesCsv(file: File): Promise<ImportResult> {

--- a/frontend/src/components/assignments/AssignmentFormEmployeeProject.tsx
+++ b/frontend/src/components/assignments/AssignmentFormEmployeeProject.tsx
@@ -1,11 +1,6 @@
+import { useMemo } from "react";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { SearchableSelect } from "@/components/common/SearchableSelect";
 import type { AssignmentFormEmployeeProjectProps } from "@/types/assignment";
 
 export function AssignmentFormEmployeeProject({
@@ -17,34 +12,50 @@ export function AssignmentFormEmployeeProject({
   projects,
   employeeError,
 }: AssignmentFormEmployeeProjectProps) {
+  const employeeOptions = useMemo(
+    () => [
+      { value: "none", label: "— Nieprzypisane (placeholder) —" },
+      ...employees.map((emp) => ({
+        value: String(emp.id),
+        label: `${emp.last_name} ${emp.first_name}`,
+        hint: emp.is_archived ? "(zarchiwizowany)" : undefined,
+      })),
+    ],
+    [employees],
+  );
+
+  const projectOptions = useMemo(
+    () =>
+      projects.map((proj) => ({
+        value: String(proj.id),
+        label: proj.name,
+        content: (
+          <span className="flex items-center gap-2 truncate">
+            <span
+              className="inline-block h-3 w-3 shrink-0 rounded-full ring-1 ring-border"
+              style={{ backgroundColor: proj.color }}
+            />
+            <span className="truncate">{proj.name}</span>
+          </span>
+        ),
+      })),
+    [projects],
+  );
+
   return (
     <>
       <div className="space-y-2">
-        <Label htmlFor="assignment-employee">Pracownik</Label>
-        <Select value={employeeId} onValueChange={onEmployeeChange}>
-          <SelectTrigger
-            id="assignment-employee"
-            className="w-full"
-            aria-invalid={!!employeeError}
-          >
-            <SelectValue placeholder="Wybierz pracownika" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="none">
-              — Nieprzypisane (placeholder) —
-            </SelectItem>
-            {employees.map((emp) => (
-              <SelectItem key={emp.id} value={String(emp.id)}>
-                {emp.last_name} {emp.first_name}
-                {emp.is_archived && (
-                  <span className="ml-2 text-xs text-muted-foreground">
-                    (zarchiwizowany)
-                  </span>
-                )}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <Label id="assignment-employee-label">Pracownik</Label>
+        <SearchableSelect
+          id="assignment-employee"
+          labelId="assignment-employee-label"
+          options={employeeOptions}
+          value={employeeId}
+          onChange={onEmployeeChange}
+          placeholder="Wybierz pracownika"
+          searchPlaceholder="Szukaj pracownika..."
+          invalid={!!employeeError}
+        />
         {employeeError && (
           <p className="text-sm text-destructive" role="alert">
             {employeeError}
@@ -53,25 +64,16 @@ export function AssignmentFormEmployeeProject({
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="assignment-project">Projekt</Label>
-        <Select value={projectId} onValueChange={onProjectChange}>
-          <SelectTrigger id="assignment-project" className="w-full">
-            <SelectValue placeholder="Wybierz projekt" />
-          </SelectTrigger>
-          <SelectContent>
-            {projects.map((proj) => (
-              <SelectItem key={proj.id} value={String(proj.id)}>
-                <span className="flex items-center gap-2">
-                  <span
-                    className="inline-block h-3 w-3 rounded-full ring-1 ring-border"
-                    style={{ backgroundColor: proj.color }}
-                  />
-                  {proj.name}
-                </span>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <Label id="assignment-project-label">Projekt</Label>
+        <SearchableSelect
+          id="assignment-project"
+          labelId="assignment-project-label"
+          options={projectOptions}
+          value={projectId}
+          onChange={onProjectChange}
+          placeholder="Wybierz projekt"
+          searchPlaceholder="Szukaj projektu..."
+        />
       </div>
     </>
   );

--- a/frontend/src/components/common/MultiSelectField.tsx
+++ b/frontend/src/components/common/MultiSelectField.tsx
@@ -1,6 +1,18 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { ChevronDown, X, Check } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { usePopoverPanel } from "@/hooks/usePopoverPanel";
 import { cn } from "@/lib/utils";
+
+/** Row height in px; rows are single-line, so the list height is predictable. */
+const ROW_HEIGHT = 32;
+const MAX_LIST_HEIGHT = 288;
+/** Search input plus the panel's own padding, on top of the list height. */
+const SEARCH_BOX_HEIGHT = 54;
 
 export interface MultiSelectOption {
   id: number;
@@ -14,6 +26,8 @@ interface MultiSelectFieldProps {
   placeholder?: string;
   isLoading?: boolean;
   emptyLabel?: string;
+  /** Id of the field's <Label>. See SearchableSelect for why not `htmlFor`. */
+  labelId?: string;
 }
 
 /**
@@ -27,22 +41,25 @@ export function MultiSelectField({
   placeholder = "Wybierz...",
   isLoading,
   emptyLabel = "Brak opcji",
+  labelId,
 }: MultiSelectFieldProps) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
-  const ref = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-        setSearch("");
-      }
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [open]);
+  const { triggerRef, container, side, preparePanel } = usePopoverPanel();
+
+  /** Height of the panel with nothing filtered out; decides where it opens. */
+  const panelHeight =
+    Math.min(Math.max(options.length, 1) * ROW_HEIGHT, MAX_LIST_HEIGHT) +
+    SEARCH_BOX_HEIGHT;
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (next) {
+      preparePanel(panelHeight);
+      setSearch("");
+    }
+  };
 
   const selectedOptions = useMemo(
     () => options.filter((o) => selectedIds.includes(o.id)),
@@ -62,12 +79,8 @@ export function MultiSelectField({
     );
 
   return (
-    <div className="relative" ref={ref}>
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="flex min-h-9 w-full flex-wrap items-center gap-1 rounded-md border border-input bg-transparent px-2 py-1.5 text-left text-sm shadow-xs transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      >
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger ref={triggerRef} aria-labelledby={labelId} className="flex min-h-9 w-full flex-wrap items-center gap-1 rounded-md border border-input bg-transparent px-2 py-1.5 text-left text-sm shadow-xs transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
         {selectedOptions.length === 0 ? (
           <span className="text-muted-foreground">{placeholder}</span>
         ) : (
@@ -93,54 +106,57 @@ export function MultiSelectField({
           ))
         )}
         <ChevronDown className="ml-auto h-4 w-4 shrink-0 text-muted-foreground" />
-      </button>
+      </PopoverTrigger>
 
-      {open && (
-        <div className="absolute left-0 top-full z-30 mt-1 w-full rounded-md border bg-background p-1 shadow-md">
-          <input
-            autoFocus
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Szukaj..."
-            className="mb-1 w-full rounded-sm border-b bg-transparent px-2 py-1.5 text-sm outline-none"
-          />
-          <div className="max-h-48 overflow-y-auto">
-            {isLoading ? (
-              <p className="px-2 py-2 text-xs text-muted-foreground">
-                Ładowanie...
-              </p>
-            ) : filtered.length === 0 ? (
-              <p className="px-2 py-2 text-xs text-muted-foreground">
-                {options.length === 0 ? emptyLabel : "Brak wyników"}
-              </p>
-            ) : (
-              filtered.map((o) => {
-                const isSelected = selectedIds.includes(o.id);
-                return (
-                  <button
-                    key={o.id}
-                    type="button"
-                    onClick={() => toggle(o.id)}
-                    className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-muted"
+      <PopoverContent
+        container={container}
+        side={side}
+        className="flex max-h-(--radix-popover-content-available-height) w-(--radix-popover-trigger-width) flex-col p-1"
+      >
+        <input
+          autoFocus
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Szukaj..."
+          aria-label="Szukaj"
+          className="mb-1 w-full shrink-0 rounded-sm border-b bg-transparent px-2 py-1.5 text-sm outline-none"
+        />
+        <div className="min-h-0 max-h-72 flex-1 overflow-y-auto">
+          {isLoading ? (
+            <p className="px-2 py-2 text-xs text-muted-foreground">
+              Ładowanie...
+            </p>
+          ) : filtered.length === 0 ? (
+            <p className="px-2 py-2 text-xs text-muted-foreground">
+              {options.length === 0 ? emptyLabel : "Brak wyników"}
+            </p>
+          ) : (
+            filtered.map((o) => {
+              const isSelected = selectedIds.includes(o.id);
+              return (
+                <button
+                  key={o.id}
+                  type="button"
+                  onClick={() => toggle(o.id)}
+                  className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-muted"
+                >
+                  <span
+                    className={cn(
+                      "flex h-4 w-4 shrink-0 items-center justify-center rounded border",
+                      isSelected
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-input",
+                    )}
                   >
-                    <span
-                      className={cn(
-                        "flex h-4 w-4 shrink-0 items-center justify-center rounded border",
-                        isSelected
-                          ? "border-primary bg-primary text-primary-foreground"
-                          : "border-input",
-                      )}
-                    >
-                      {isSelected && <Check className="h-3 w-3" />}
-                    </span>
-                    {o.name}
-                  </button>
-                );
-              })
-            )}
-          </div>
+                    {isSelected && <Check className="h-3 w-3" />}
+                  </span>
+                  {o.name}
+                </button>
+              );
+            })
+          )}
         </div>
-      )}
-    </div>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/frontend/src/components/common/SearchableSelect.tsx
+++ b/frontend/src/components/common/SearchableSelect.tsx
@@ -1,0 +1,226 @@
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { Check, ChevronDown } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { usePopoverPanel } from "@/hooks/usePopoverPanel";
+import { cn } from "@/lib/utils";
+
+/** Row height in px; rows are single-line, so the list height is predictable. */
+const ROW_HEIGHT = 32;
+const MAX_LIST_HEIGHT = 288;
+/** Search input plus the panel's own padding, on top of the list height. */
+const SEARCH_BOX_HEIGHT = 54;
+
+export interface SearchableSelectOption {
+  value: string;
+  /** Plain text used for searching and as the trigger label fallback. */
+  label: string;
+  /** Custom rendering for the row and the trigger (e.g. a project color dot). */
+  content?: ReactNode;
+  /** Muted suffix shown after the label, e.g. "(zarchiwizowany)". */
+  hint?: string;
+}
+
+interface SearchableSelectProps {
+  options: SearchableSelectOption[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  isLoading?: boolean;
+  emptyLabel?: string;
+  disabled?: boolean;
+  /** Rendered on the trigger, for tests and for focusing the field. */
+  id?: string;
+  /**
+   * Id of the field's <Label>. Deliberately not wired with `htmlFor`: the browser
+   * forwards a label click to the labelled control, which would immediately
+   * reopen the panel that the same click just dismissed.
+   */
+  labelId?: string;
+  invalid?: boolean;
+  className?: string;
+}
+
+/**
+ * Single-choice dropdown with a search box, for lists too long to scan by eye
+ * (employees, projects, teams). Visually matches the plain Select trigger.
+ */
+export function SearchableSelect({
+  options,
+  value,
+  onChange,
+  placeholder = "Wybierz...",
+  searchPlaceholder = "Szukaj...",
+  isLoading,
+  emptyLabel = "Brak opcji",
+  disabled,
+  id,
+  labelId,
+  invalid,
+  className,
+}: SearchableSelectProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [highlight, setHighlight] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+  const { triggerRef, container, side, preparePanel } = usePopoverPanel();
+
+  /** Height of the panel with nothing filtered out; decides where it opens. */
+  const panelHeight =
+    Math.min(Math.max(options.length, 1) * ROW_HEIGHT, MAX_LIST_HEIGHT) +
+    SEARCH_BOX_HEIGHT;
+
+  const selected = useMemo(
+    () => options.find((o) => o.value === value),
+    [options, value],
+  );
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return q
+      ? options.filter((o) => o.label.toLowerCase().includes(q))
+      : options;
+  }, [options, search]);
+
+  // Derived, so filtering the list can never leave the highlight past its end.
+  const activeIndex = Math.min(highlight, Math.max(filtered.length - 1, 0));
+
+  // Deferred by a frame: right after opening, Radix has not positioned the panel
+  // yet, and scrolling an unlaid-out box does nothing.
+  useEffect(() => {
+    if (!open) return;
+    const frame = requestAnimationFrame(() => {
+      listRef.current
+        ?.querySelector('[data-highlighted="true"]')
+        ?.scrollIntoView({ block: "nearest" });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [activeIndex, open]);
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (next) {
+      preparePanel(panelHeight);
+      setSearch("");
+      const index = options.findIndex((o) => o.value === value);
+      setHighlight(index === -1 ? 0 : index);
+    }
+  };
+
+  const select = (next: string) => {
+    onChange(next);
+    setOpen(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      if (filtered.length === 0) return;
+      const step = e.key === "ArrowDown" ? 1 : -1;
+      setHighlight((activeIndex + step + filtered.length) % filtered.length);
+      return;
+    }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      const option = filtered[activeIndex];
+      if (option) select(option.value);
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger
+        ref={triggerRef}
+        id={id}
+        disabled={disabled}
+        aria-labelledby={labelId}
+        aria-invalid={invalid}
+        className={cn(
+          "border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 dark:bg-input/30 dark:hover:bg-input/50 flex h-9 w-full items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+      >
+        <span className="flex min-w-0 items-center gap-2 truncate">
+          {selected ? (
+            <>
+              {selected.content ?? selected.label}
+              {selected.hint && (
+                <span className="text-xs text-muted-foreground">
+                  {selected.hint}
+                </span>
+              )}
+            </>
+          ) : (
+            <span className="text-muted-foreground">
+              {isLoading ? "Ładowanie..." : placeholder}
+            </span>
+          )}
+        </span>
+        <ChevronDown className="size-4 shrink-0 opacity-50" />
+      </PopoverTrigger>
+
+      <PopoverContent
+        container={container}
+        side={side}
+        className="flex max-h-(--radix-popover-content-available-height) w-(--radix-popover-trigger-width) flex-col p-1"
+      >
+        <input
+          autoFocus
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setHighlight(0);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder={searchPlaceholder}
+          aria-label={searchPlaceholder}
+          className="mb-1 w-full shrink-0 rounded-sm border-b bg-transparent px-2 py-1.5 text-sm outline-none"
+        />
+        <div
+          ref={listRef}
+          className="min-h-0 max-h-72 flex-1 overflow-y-auto"
+        >
+          {isLoading ? (
+            <p className="px-2 py-2 text-xs text-muted-foreground">
+              Ładowanie...
+            </p>
+          ) : filtered.length === 0 ? (
+            <p className="px-2 py-2 text-xs text-muted-foreground">
+              {options.length === 0 ? emptyLabel : "Brak wyników"}
+            </p>
+          ) : (
+            filtered.map((option, index) => (
+              <button
+                key={option.value}
+                type="button"
+                data-highlighted={index === highlight}
+                onMouseEnter={() => setHighlight(index)}
+                onClick={() => select(option.value)}
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm data-[highlighted=true]:bg-accent data-[highlighted=true]:text-accent-foreground"
+              >
+                <Check
+                  className={cn(
+                    "size-4 shrink-0",
+                    option.value === value ? "opacity-100" : "opacity-0",
+                  )}
+                />
+                <span className="min-w-0 flex-1 truncate">
+                  {option.content ?? option.label}
+                </span>
+                {option.hint && (
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {option.hint}
+                  </span>
+                )}
+              </button>
+            ))
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/src/components/employees/CapacityDialog.tsx
+++ b/frontend/src/components/employees/CapacityDialog.tsx
@@ -1,0 +1,447 @@
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { format, parseISO, startOfMonth, subDays } from "date-fns";
+import { Pencil, Plus, Trash2 } from "lucide-react";
+import { DialogWrapper } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  createCapacity,
+  deleteCapacity,
+  fetchCapacities,
+  updateCapacity,
+} from "@/api/employees";
+import { CAPACITY_TYPE_OPTIONS, formatCapacity } from "@/lib/capacity";
+import { cn } from "@/lib/utils";
+import type {
+  CapacityDialogProps,
+  CapacityInput,
+  CapacityType,
+  EmployeeCapacity,
+} from "@/types/employee";
+
+/**
+ * The date the backend backfills as "from always". Showing it verbatim would
+ * suggest a 1900 hire date, so it is rendered as an open start instead.
+ */
+const OPEN_START = "1900-01-01";
+
+function formatDate(value: string): string {
+  return format(parseISO(value), "dd.MM.yyyy");
+}
+
+/** The last day covered by the period preceding `validFrom`. */
+function dayBefore(validFrom: string): string {
+  return format(subDays(parseISO(validFrom), 1), "dd.MM.yyyy");
+}
+
+/** A period runs until the day before the next one starts. */
+function formatRange(
+  capacity: EmployeeCapacity,
+  next: EmployeeCapacity | undefined,
+): string {
+  const from =
+    capacity.valid_from === OPEN_START
+      ? "od zawsze"
+      : `od ${formatDate(capacity.valid_from)}`;
+  if (!next) return from;
+  const until = dayBefore(next.valid_from);
+  return capacity.valid_from === OPEN_START
+    ? `do ${until}`
+    : `${from} do ${until}`;
+}
+
+type DraftState = {
+  /** null when adding a new period. */
+  id: number | null;
+  validFrom: string;
+  capacityType: CapacityType;
+  capacityValue: string;
+};
+
+function emptyDraft(): DraftState {
+  return {
+    id: null,
+    // Contract changes almost always take effect from the 1st; never default
+    // to a past date, which would silently rewrite closed months.
+    validFrom: format(startOfMonth(new Date()), "yyyy-MM-dd"),
+    capacityType: "percentage",
+    capacityValue: "",
+  };
+}
+
+function draftFrom(capacity: EmployeeCapacity): DraftState {
+  return {
+    id: capacity.id,
+    validFrom: capacity.valid_from,
+    capacityType: capacity.capacity_type,
+    capacityValue: String(capacity.capacity_value),
+  };
+}
+
+export function CapacityDialog({
+  open,
+  onClose,
+  employee,
+}: CapacityDialogProps) {
+  const queryClient = useQueryClient();
+  const employeeId = employee?.id ?? 0;
+  const [draft, setDraft] = useState<DraftState | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<EmployeeCapacity | null>(
+    null,
+  );
+
+  const { data: capacities = [], isLoading } = useQuery({
+    queryKey: ["capacities", employeeId],
+    queryFn: () => fetchCapacities(employeeId),
+    enabled: open && employeeId > 0,
+  });
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["capacities", employeeId] });
+    queryClient.invalidateQueries({ queryKey: ["employees"] });
+    // Occupancy is computed from capacity, so both timelines are now stale.
+    queryClient.invalidateQueries({ queryKey: ["timeline"] });
+    queryClient.invalidateQueries({ queryKey: ["project-timeline"] });
+  };
+
+  const saveMutation = useMutation({
+    mutationFn: ({ id, data }: { id: number | null; data: CapacityInput }) =>
+      id === null
+        ? createCapacity(employeeId, data)
+        : updateCapacity(employeeId, id, data),
+    onSuccess: (_data, variables) => {
+      invalidate();
+      setDraft(null);
+      toast.success(
+        variables.id === null ? "Okres dodany" : "Okres zaktualizowany",
+      );
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (capacityId: number) => deleteCapacity(employeeId, capacityId),
+    onSuccess: () => {
+      invalidate();
+      setDeleteTarget(null);
+      toast.success("Okres usunięty");
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const sorted = useMemo(
+    () => [...capacities].sort((a, b) => a.valid_from.localeCompare(b.valid_from)),
+    [capacities],
+  );
+
+  const leadingGap = sorted.length > 0 && sorted[0].valid_from !== OPEN_START;
+
+  const handleSave = () => {
+    if (!draft) return;
+    const value = Number(draft.capacityValue.replace(",", "."));
+    if (!Number.isFinite(value) || value <= 0) {
+      toast.error("Podaj wartość większą od zera");
+      return;
+    }
+    saveMutation.mutate({
+      id: draft.id,
+      data: {
+        valid_from: draft.validFrom,
+        capacity_type: draft.capacityType,
+        capacity_value: value,
+      },
+    });
+  };
+
+  const isLastPeriod = sorted.length === 1;
+
+  return (
+    <>
+      <DialogWrapper
+        open={open}
+        onClose={onClose}
+        title={
+          employee
+            ? `Wymiar etatu: ${employee.last_name} ${employee.first_name}`
+            : "Wymiar etatu"
+        }
+        description="Każdy okres obowiązuje od wskazanej daty do początku następnego okresu. Zmiana wielkości etatu wpływa tylko na dany okres, wcześniejsze miesiące zachowują dotychczasowe wyliczenia dla obłożenia i assignmentów."
+        contentClassName="max-w-xl"
+        footer={
+          <Button variant="outline" onClick={onClose}>
+            Zamknij
+          </Button>
+        }
+      >
+        <div className="space-y-2">
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground">Wczytywanie...</p>
+          ) : (
+            <>
+              {leadingGap && (
+                <div className="flex items-center justify-between rounded-md border border-dashed px-3 py-2 text-sm text-muted-foreground">
+                  <span>do {dayBefore(sorted[0].valid_from)}</span>
+                  <span>Niezatrudniony</span>
+                </div>
+              )}
+
+              {sorted.map((capacity, index) =>
+                draft?.id === capacity.id ? (
+                  <ExpandPanel key={capacity.id}>
+                    <CapacityEditor
+                      draft={draft}
+                      onChange={setDraft}
+                      onSave={handleSave}
+                      onCancel={() => setDraft(null)}
+                      isPending={saveMutation.isPending}
+                    />
+                  </ExpandPanel>
+                ) : deleteTarget?.id === capacity.id ? (
+                  <ExpandPanel key={capacity.id}>
+                    <DeleteConfirm
+                      capacity={capacity}
+                      isFirst={index === 0}
+                      onConfirm={() => deleteMutation.mutate(capacity.id)}
+                      onCancel={() => setDeleteTarget(null)}
+                      isPending={deleteMutation.isPending}
+                    />
+                  </ExpandPanel>
+                ) : (
+                  <div
+                    key={capacity.id}
+                    className="flex items-center gap-4 rounded-md border px-3 py-2"
+                  >
+                    {/* Fixed width, wide enough for the longest range, so the
+                        badges line up across rows instead of tracking the text. */}
+                    <span className="w-[13rem] shrink-0 text-sm">
+                      {formatRange(capacity, sorted[index + 1])}
+                    </span>
+                    <Badge
+                      variant={capacity.is_full_time ? "secondary" : "default"}
+                    >
+                      {formatCapacity(capacity)}
+                    </Badge>
+                    <div className="ml-auto flex items-center">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setDraft(draftFrom(capacity))}
+                        aria-label={`Edytuj okres ${formatRange(capacity, sorted[index + 1])}`}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={isLastPeriod}
+                        title={
+                          isLastPeriod
+                            ? "Nie można usunąć jedynego okresu"
+                            : undefined
+                        }
+                        onClick={() => setDeleteTarget(capacity)}
+                        aria-label={`Usuń okres ${formatRange(capacity, sorted[index + 1])}`}
+                      >
+                        <Trash2
+                          className={cn(
+                            "h-4 w-4",
+                            !isLastPeriod && "text-destructive",
+                          )}
+                        />
+                      </Button>
+                    </div>
+                  </div>
+                ),
+              )}
+
+              {draft?.id === null ? (
+                <ExpandPanel>
+                  <CapacityEditor
+                    draft={draft}
+                    onChange={setDraft}
+                    onSave={handleSave}
+                    onCancel={() => setDraft(null)}
+                    isPending={saveMutation.isPending}
+                  />
+                </ExpandPanel>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setDraft(emptyDraft())}
+                >
+                  <Plus className="mr-2 h-4 w-4" />
+                  Dodaj okres
+                </Button>
+              )}
+            </>
+          )}
+        </div>
+      </DialogWrapper>
+    </>
+  );
+}
+
+/**
+ * Grows its content to full height on mount instead of snapping the dialog
+ * open. `grid-rows` is what makes it work: `height` cannot transition from
+ * `auto`, but `0fr` to `1fr` can, so the panel measures itself.
+ */
+function ExpandPanel({ children }: { children: ReactNode }) {
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    // Next frame, so the browser paints the collapsed state first and has
+    // something to animate from.
+    const frame = requestAnimationFrame(() => setExpanded(true));
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  return (
+    <div
+      className={cn(
+        "grid transition-all duration-200 ease-out",
+        expanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
+      )}
+    >
+      <div className="overflow-hidden">{children}</div>
+    </div>
+  );
+}
+
+/**
+ * Confirmation is inline, replacing the row it is about, rather than a second
+ * modal: a dialog opened on top of this one renders behind it, and stacking two
+ * modals to delete a list row is more ceremony than the action deserves.
+ */
+function DeleteConfirm({
+  capacity,
+  isFirst,
+  onConfirm,
+  onCancel,
+  isPending,
+}: {
+  capacity: EmployeeCapacity;
+  isFirst: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isPending: boolean;
+}) {
+  return (
+    <div className="space-y-2 rounded-md border border-destructive/50 bg-destructive/5 p-3">
+      <p className="text-sm">
+        Usunąć okres <strong>{formatCapacity(capacity)}</strong>?
+      </p>
+      <ul className="list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+        <li>
+          {isFirst
+            ? "Czas przed następnym okresem stanie się okresem bez zatrudnienia."
+            : "Poprzedni okres rozszerzy się na ten zakres dat."}
+        </li>
+        <li>Obłożenie i dostępne godziny w tym zakresie zostaną przeliczone.</li>
+      </ul>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="destructive"
+          size="sm"
+          onClick={onConfirm}
+          disabled={isPending}
+        >
+          {isPending ? "Usuwanie..." : "Tak, usuń"}
+        </Button>
+        <Button variant="outline" size="sm" onClick={onCancel}>
+          Nie
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function CapacityEditor({
+  draft,
+  onChange,
+  onSave,
+  onCancel,
+  isPending,
+}: {
+  draft: DraftState;
+  onChange: (draft: DraftState) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  isPending: boolean;
+}) {
+  const isPercentage = draft.capacityType === "percentage";
+
+  return (
+    <div className="space-y-3 rounded-md border bg-muted/30 p-3">
+      {/* Date and value need only as much room as their content; the rest goes
+          to the type select so its longest option is not truncated. */}
+      <div className="grid grid-cols-[9rem_1fr_6.5rem] gap-3">
+        <div className="space-y-2">
+          <Label htmlFor="capacity-valid-from">Obowiązuje od</Label>
+          <Input
+            id="capacity-valid-from"
+            type="date"
+            value={draft.validFrom}
+            onChange={(e) => onChange({ ...draft, validFrom: e.target.value })}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="capacity-type">Typ</Label>
+          <Select
+            value={draft.capacityType}
+            onValueChange={(value) =>
+              onChange({ ...draft, capacityType: value as CapacityType })
+            }
+          >
+            <SelectTrigger id="capacity-type" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {CAPACITY_TYPE_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="capacity-value">
+            {isPercentage ? "Wartość (%)" : "Godziny / msc"}
+          </Label>
+          <Input
+            id="capacity-value"
+            type="number"
+            min="0.01"
+            step={isPercentage ? "1" : "0.5"}
+            placeholder={isPercentage ? "100" : "40"}
+            value={draft.capacityValue}
+            onChange={(e) =>
+              onChange({ ...draft, capacityValue: e.target.value })
+            }
+          />
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button size="sm" onClick={onSave} disabled={isPending}>
+          {isPending ? "Zapisywanie..." : "Zapisz"}
+        </Button>
+        <Button variant="outline" size="sm" onClick={onCancel}>
+          Anuluj
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/employees/CapacityDialog.tsx
+++ b/frontend/src/components/employees/CapacityDialog.tsx
@@ -425,6 +425,7 @@ function CapacityEditor({
             id="capacity-value"
             type="number"
             min="0.01"
+            max={isPercentage ? "100" : "744"}
             step={isPercentage ? "1" : "0.5"}
             placeholder={isPercentage ? "100" : "40"}
             value={draft.capacityValue}

--- a/frontend/src/components/employees/EmployeeForm.tsx
+++ b/frontend/src/components/employees/EmployeeForm.tsx
@@ -1,15 +1,9 @@
-import { type FormEvent, useEffect, useState } from "react";
+import { type FormEvent, useEffect, useMemo, useState } from "react";
 import { DialogWrapper } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { MultiSelectField } from "@/components/common/MultiSelectField";
+import { SearchableSelect } from "@/components/common/SearchableSelect";
 import { useTeams } from "@/hooks/useTeams";
 import { useTechnologies } from "@/hooks/useTechnologies";
 import type { Employee, EmployeeFormProps } from "@/types/employee";
@@ -48,6 +42,14 @@ export function EmployeeForm({
   useEffect(() => {
     setForm(initialFormState(employee));
   }, [employee]);
+
+  const teamOptions = useMemo(
+    () => [
+      { value: "none", label: "— Brak —" },
+      ...teams.map((t) => ({ value: String(t.id), label: t.name })),
+    ],
+    [teams],
+  );
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -106,27 +108,22 @@ export function EmployeeForm({
         </p>
       </div>
       <div className="space-y-2">
-        <Label>Zespół</Label>
-        <Select
+        <Label id="employee-team-label">Zespół</Label>
+        <SearchableSelect
+          id="employee-team"
+          labelId="employee-team-label"
+          options={teamOptions}
           value={form.teamId}
-          onValueChange={(v) => setForm((f) => ({ ...f, teamId: v }))}
-        >
-          <SelectTrigger className="w-full">
-            <SelectValue placeholder={teamsLoading ? "Ładowanie..." : undefined} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="none">— Brak —</SelectItem>
-            {teams.map((t) => (
-              <SelectItem key={t.id} value={String(t.id)}>
-                {t.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          onChange={(v) => setForm((f) => ({ ...f, teamId: v }))}
+          isLoading={teamsLoading}
+          searchPlaceholder="Szukaj zespołu..."
+          emptyLabel="Brak zespołów. Dodaj je w Ustawieniach"
+        />
       </div>
       <div className="space-y-2">
-        <Label>Technologie</Label>
+        <Label id="employee-technologies-label">Technologie</Label>
         <MultiSelectField
+          labelId="employee-technologies-label"
           options={technologies}
           selectedIds={form.technologyIds}
           onChange={(ids) => setForm((f) => ({ ...f, technologyIds: ids }))}

--- a/frontend/src/components/employees/EmployeeList.tsx
+++ b/frontend/src/components/employees/EmployeeList.tsx
@@ -9,6 +9,7 @@ import { useTechnologies } from "@/hooks/useTechnologies";
 import {
   Archive,
   ArchiveRestore,
+  CalendarClock,
   Pencil,
   Plus,
   Trash2,
@@ -35,8 +36,10 @@ import {
   unarchiveEmployee,
   updateEmployee,
 } from "@/api/employees";
+import { formatCapacity } from "@/lib/capacity";
 import type { Employee, EmployeeCreateData } from "@/types/employee";
 import { EmployeeForm } from "./EmployeeForm";
+import { CapacityDialog } from "./CapacityDialog";
 
 type StatusFilter = "active" | "archived" | "all";
 
@@ -54,6 +57,24 @@ const EMPLOYEE_COLUMNS: DataTableColumn<Employee>[] = [
         )}
       </span>
     ),
+  },
+  {
+    id: "capacity",
+    header: "Etat",
+    // Fixed width: the cell holds anything from an em dash to "Niezatrudniony",
+    // and letting it size itself makes the neighbouring columns shift per row.
+    className: "w-36",
+    // Full time is the norm, so only the exceptions are worth a badge.
+    cell: (emp) =>
+      !emp.current_capacity ? (
+        <Badge variant="outline" className="text-muted-foreground">
+          Niezatrudniony
+        </Badge>
+      ) : emp.current_capacity.is_full_time ? (
+        <span className="text-muted-foreground">—</span>
+      ) : (
+        <Badge>{formatCapacity(emp.current_capacity)}</Badge>
+      ),
   },
   {
     id: "email",
@@ -94,6 +115,7 @@ export function EmployeeList() {
   const queryClient = useQueryClient();
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("active");
   const [archiveTarget, setArchiveTarget] = useState<Employee | null>(null);
+  const [capacityTarget, setCapacityTarget] = useState<Employee | null>(null);
   const [selectedTeamIds, setSelectedTeamIds] = useState<number[]>([]);
   const [selectedTechnologyIds, setSelectedTechnologyIds] = useState<number[]>(
     [],
@@ -312,6 +334,15 @@ export function EmployeeList() {
             >
               <Pencil className="h-4 w-4" />
             </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setCapacityTarget(emp)}
+              aria-label={`Wymiar etatu: ${emp.last_name} ${emp.first_name}`}
+              title="Wymiar etatu"
+            >
+              <CalendarClock className="h-4 w-4" />
+            </Button>
             {emp.is_archived ? (
               <Button
                 variant="ghost"
@@ -355,6 +386,12 @@ export function EmployeeList() {
         isSubmitting={
           crud.createMutation.isPending || crud.updateMutation.isPending
         }
+      />
+
+      <CapacityDialog
+        open={capacityTarget !== null}
+        onClose={() => setCapacityTarget(null)}
+        employee={capacityTarget}
       />
 
       <ConfirmDialog

--- a/frontend/src/components/timeline/Timeline.tsx
+++ b/frontend/src/components/timeline/Timeline.tsx
@@ -44,6 +44,8 @@ import {
   TIMELINE_LEFT_PANEL_WIDTH,
   PLACEHOLDER_EMPLOYEE_ID,
 } from "@/lib/constants";
+import { dailyCapacityHours } from "@/lib/capacity";
+import type { CapacityPeriod } from "@/types/employee";
 import { TimelineBarDragPreview } from "./TimelineBarDragPreview";
 
 type TimelineProps = {
@@ -58,19 +60,22 @@ function calcOccupancyInRange(
   dateTo: string | null,
   visibleStart: Date,
   visibleEnd: Date,
+  capacityPeriods: CapacityPeriod[] | undefined,
 ): number {
   const rangeStart = dateFrom ? parseISO(dateFrom) : visibleStart;
   const rangeEnd = dateTo ? parseISO(dateTo) : visibleEnd;
 
   let totalHours = 0;
-  let workingDays = 0;
+  // Measured against what the person is contracted for, so a part-timer with a
+  // full plate reads as 100% and survives a "busier than 80%" filter.
+  let availableHours = 0;
 
   let current = rangeStart;
   while (current <= rangeEnd) {
     const dow = getDay(current); // 0=Sun, 6=Sat
     const dateKey = format(current, "yyyy-MM-dd");
     if (dow !== 0 && dow !== 6 && !holidayMap[dateKey]) {
-      workingDays++;
+      availableHours += dailyCapacityHours(capacityPeriods, dateKey);
 
       const isOnVacation = vacations.some((v) => {
         const vStart = parseISO(v.start_date);
@@ -91,8 +96,8 @@ function calcOccupancyInRange(
     current = addDays(current, 1);
   }
 
-  if (workingDays === 0) return 0;
-  return Math.round((totalHours / (workingDays * 8)) * 100);
+  if (availableHours === 0) return 0;
+  return Math.round((totalHours / availableHours) * 100);
 }
 
 export function Timeline({ onNavigate }: TimelineProps = {}) {
@@ -452,6 +457,7 @@ export function Timeline({ onNavigate }: TimelineProps = {}) {
         dateTo,
         startDate,
         endDate,
+        emp.capacity_periods,
       );
       if (minPct !== null && pct < minPct) return false;
       if (maxPct !== null && pct > maxPct) return false;
@@ -611,6 +617,7 @@ export function Timeline({ onNavigate }: TimelineProps = {}) {
                     employeeId={emp.id}
                     name={emp.name}
                     team={emp.team}
+                    capacity={emp.capacity}
                     assignments={emp.assignments}
                     vacations={emp.vacations}
                     occupancy={emp.occupancy}

--- a/frontend/src/components/timeline/TimelineRow.tsx
+++ b/frontend/src/components/timeline/TimelineRow.tsx
@@ -13,6 +13,7 @@ import {
   getUtilColor,
   TIMELINE_LEFT_PANEL_WIDTH,
 } from "@/lib/constants";
+import { formatCapacity } from "@/lib/capacity";
 import {
   getDateFromMonthlyPixelPosition,
   computeBarPositionMonthly,
@@ -28,6 +29,7 @@ export function TimelineRow({
   employeeId,
   name,
   team,
+  capacity,
   assignments,
   vacations = [],
   occupancy,
@@ -192,11 +194,23 @@ export function TimelineRow({
         >
           <div className="min-w-0 flex-1">
             <div className="truncate text-sm font-medium">{name}</div>
-            {team && (
-              <Badge variant="secondary" className="mt-0.5 text-[10px]">
-                {team}
-              </Badge>
-            )}
+            <div className="mt-0.5 flex flex-wrap items-center gap-1">
+              {team && (
+                <Badge variant="secondary" className="text-[10px]">
+                  {team}
+                </Badge>
+              )}
+              {/* Only for part-timers: the percentages in this row are shares
+                  of their shorter day, which is worth saying out loud. */}
+              {capacity && !capacity.is_full_time && (
+                <Badge
+                  className="text-[10px]"
+                  title="Wymiar etatu. Obłożenie liczy się względem tej wartości."
+                >
+                  {formatCapacity(capacity)}
+                </Badge>
+              )}
+            </div>
           </div>
         </div>
       )}

--- a/frontend/src/components/timeline/TimelineSummaryRow.tsx
+++ b/frontend/src/components/timeline/TimelineSummaryRow.tsx
@@ -9,6 +9,7 @@ import {
 } from "date-fns";
 import type { TimelineSummaryRowProps, DaySummary } from "@/types/timeline";
 import { getUtilColor } from "@/lib/constants";
+import { dailyCapacityHours } from "@/lib/capacity";
 import { MONTH_WIDTH, DAY_WIDTH } from "./TimelineHeader";
 
 export function TimelineSummaryRow({
@@ -31,9 +32,13 @@ export function TimelineSummaryRow({
 
       let totalHours = 0;
       let activeEmployees = 0;
+      // Availability is the sum of contracted days, not one flat day each:
+      // part-timers bring less, and people who have not started bring nothing.
+      let availableHours = 0;
 
       for (const emp of employees) {
         activeEmployees++;
+        availableHours += dailyCapacityHours(emp.capacity_periods, day.key);
         for (const a of emp.assignments) {
           const aStart = parseISO(a.start_date);
           const aEnd = parseISO(a.end_date);
@@ -43,7 +48,6 @@ export function TimelineSummaryRow({
         }
       }
 
-      const availableHours = activeEmployees * 8;
       const ftePct =
         availableHours > 0
           ? Math.round((totalHours / availableHours) * 100)
@@ -70,15 +74,18 @@ export function TimelineSummaryRow({
       const days = eachDayOfInterval({ start: mStart, end: mEnd });
 
       let totalHours = 0;
-      let workingDayCount = 0;
+      // Summed per employee per day rather than headcount * days * 8, so
+      // part-timers and people who have not started contribute what they
+      // really can. The gap between the two is the unallocated capacity.
+      let availableHours = 0;
 
       for (const day of days) {
         const dayKey = format(day, "yyyy-MM-dd");
         const dow = day.getDay();
         if (dow === 0 || dow === 6 || holidayMap[dayKey]) continue;
-        workingDayCount++;
 
         for (const emp of employees) {
+          availableHours += dailyCapacityHours(emp.capacity_periods, dayKey);
           for (const a of emp.assignments) {
             const aStart = parseISO(a.start_date);
             const aEnd = parseISO(a.end_date);
@@ -89,7 +96,6 @@ export function TimelineSummaryRow({
         }
       }
 
-      const availableHours = employees.length * workingDayCount * 8;
       const ftePct =
         availableHours > 0
           ? Math.round((totalHours / availableHours) * 100)

--- a/frontend/src/components/ui/DataTable.tsx
+++ b/frontend/src/components/ui/DataTable.tsx
@@ -25,6 +25,7 @@ export function DataTable<T>({
                   className={cn(
                     "px-4 py-3 text-sm font-medium",
                     col.align === "right" ? "text-right" : "text-left",
+                    col.className,
                   )}
                 >
                   {col.header}
@@ -44,6 +45,7 @@ export function DataTable<T>({
                     className={cn(
                       "px-4 py-3",
                       col.align === "right" ? "text-right" : "text-left",
+                      col.className,
                     )}
                   >
                     <div
@@ -106,6 +108,7 @@ export function DataTable<T>({
                   className={cn(
                     "px-4 py-3",
                     col.align === "right" ? "text-right" : "text-left",
+                    col.className,
                   )}
                 >
                   {col.cell(row)}

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import * as React from "react";
+import { Popover as PopoverPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+/**
+ * Portalled popover panel. Radix flips it above the trigger and caps its height
+ * to the free space, so panels near the bottom of the viewport are never clipped.
+ */
+function PopoverContent({
+  className,
+  align = "start",
+  sideOffset = 4,
+  collisionPadding = 8,
+  container,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content> & {
+  /** Portal target; defaults to document.body. See usePopoverContainer(). */
+  container?: HTMLElement | null;
+}) {
+  return (
+    <PopoverPrimitive.Portal container={container ?? undefined}>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2 z-50 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger };

--- a/frontend/src/hooks/usePopoverPanel.ts
+++ b/frontend/src/hooks/usePopoverPanel.ts
@@ -1,0 +1,38 @@
+import { useRef, useState } from "react";
+
+/** Gap kept between the panel and the viewport edge, matching collisionPadding. */
+const EDGE_PADDING = 12;
+
+/**
+ * Positioning helpers shared by the searchable dropdown panels.
+ *
+ * `container`: Radix portals panels to <body> by default. Inside a modal dialog
+ * that places the panel outside the dialog's scroll lock, which swallows wheel
+ * events over the list, and outside its dismissable layer, which makes clicks
+ * elsewhere in the dialog flicker. Portalling into the dialog keeps the panel in
+ * that subtree while Popper still positions it against the viewport.
+ *
+ * `side`: chosen here, from the unfiltered panel height, instead of letting Radix
+ * flip on its own. Radix only flips away from its preferred side when that side
+ * does not fit, so pinning the side we picked stops the panel from jumping from
+ * above the field to below it as search results shrink the list.
+ */
+export function usePopoverPanel() {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+  const [side, setSide] = useState<"top" | "bottom">("bottom");
+
+  /** Call when the panel opens, with its expected unfiltered height in px. */
+  const preparePanel = (panelHeight: number) => {
+    const trigger = triggerRef.current;
+    setContainer(
+      trigger?.closest<HTMLElement>('[data-slot="dialog-content"]') ?? null,
+    );
+    if (!trigger) return;
+    const spaceBelow =
+      window.innerHeight - trigger.getBoundingClientRect().bottom - EDGE_PADDING;
+    setSide(spaceBelow >= panelHeight ? "bottom" : "top");
+  };
+
+  return { triggerRef, container, side, preparePanel };
+}

--- a/frontend/src/lib/capacity.ts
+++ b/frontend/src/lib/capacity.ts
@@ -1,0 +1,51 @@
+import type {
+  CapacityPeriod,
+  CapacityType,
+  EmployeeCapacity,
+} from "@/types/employee";
+
+/** Hours in a full-time working day — the norm a percentage is measured against. */
+export const FULL_TIME_DAILY_HOURS = 8;
+
+// Same wording as the assignment modal's allocation type, so the two forms read
+// as one vocabulary.
+export const CAPACITY_TYPE_OPTIONS: { value: CapacityType; label: string }[] = [
+  { value: "percentage", label: "Procent (%)" },
+  { value: "monthly_hours", label: "Godziny / msc" },
+];
+
+/** Short label for a capacity, e.g. "50%" or "40h/mies.". */
+export function formatCapacity(capacity: EmployeeCapacity): string {
+  if (capacity.capacity_type === "monthly_hours") {
+    return `${formatNumber(capacity.capacity_value)}h/msc`;
+  }
+  return `${formatNumber(capacity.capacity_value)}%`;
+}
+
+function formatNumber(value: number): string {
+  return Number.isInteger(value)
+    ? String(value)
+    : String(Number(value.toFixed(2)));
+}
+
+/**
+ * Contracted hours on a given day, from the run-length encoded periods the
+ * timeline endpoint returns.
+ *
+ * Zero means no period covers the day, i.e. the employee was not employed
+ * then. Missing periods (older cached responses) fall back to a full-time day
+ * so availability never silently collapses to nothing.
+ */
+export function dailyCapacityHours(
+  periods: CapacityPeriod[] | undefined,
+  dateKey: string,
+): number {
+  if (!periods || periods.length === 0) return FULL_TIME_DAILY_HOURS;
+
+  let hours = 0;
+  for (const period of periods) {
+    if (period.from > dateKey) break;
+    hours = period.daily_hours;
+  }
+  return hours;
+}

--- a/frontend/src/types/assignment.ts
+++ b/frontend/src/types/assignment.ts
@@ -1,3 +1,5 @@
+import type { CapacityPeriod, EmployeeCapacity } from "./employee";
+
 export interface TimelineAssignment {
   id: number;
   project_id: number;
@@ -34,6 +36,14 @@ export interface TimelineEmployee {
   assignments: TimelineAssignment[];
   vacations?: VacationInfo[];
   occupancy: Record<string, PeriodOccupancy>;
+  /**
+   * Contracted hours per working day across the requested range, split only
+   * where the figure actually changes. Lets the client size availability
+   * without re-deriving the capacity rules.
+   */
+  capacity_periods?: CapacityPeriod[];
+  /** Capacity in force today; null when the employee has not started yet. */
+  capacity?: EmployeeCapacity | null;
 }
 
 export interface HolidayInfo {

--- a/frontend/src/types/employee.ts
+++ b/frontend/src/types/employee.ts
@@ -1,6 +1,33 @@
 import type { Team } from "./team";
 import type { Technology } from "./technology";
 
+export type CapacityType = "percentage" | "monthly_hours";
+
+/**
+ * One effective-dated slice of an employee's contracted capacity. A slice runs
+ * until the next one starts; time before the earliest slice is uncovered and
+ * means the employee had not started yet.
+ */
+export interface EmployeeCapacity {
+  id: number;
+  valid_from: string;
+  capacity_type: CapacityType;
+  capacity_value: number;
+  is_full_time: boolean;
+}
+
+export interface CapacityInput {
+  valid_from: string;
+  capacity_type: CapacityType;
+  capacity_value: number;
+}
+
+/** Contracted hours per working day, in force from `from` until the next entry. */
+export interface CapacityPeriod {
+  from: string;
+  daily_hours: number;
+}
+
 export interface Employee {
   id: number;
   first_name: string;
@@ -10,6 +37,9 @@ export interface Employee {
   email: string | null;
   is_archived: boolean;
   created_at: string;
+  capacities: EmployeeCapacity[];
+  /** In force today; null when no period covers today. */
+  current_capacity: EmployeeCapacity | null;
 }
 
 export interface EmployeeCreateData {
@@ -37,4 +67,10 @@ export interface EmployeeFormProps {
 export interface ImportCsvDialogProps {
   open: boolean;
   onClose: () => void;
+}
+
+export interface CapacityDialogProps {
+  open: boolean;
+  onClose: () => void;
+  employee: Employee | null;
 }

--- a/frontend/src/types/timeline.ts
+++ b/frontend/src/types/timeline.ts
@@ -4,6 +4,7 @@ import type {
   PeriodOccupancy,
   VacationInfo,
 } from "./assignment";
+import type { EmployeeCapacity } from "./employee";
 
 export type ViewMode = "monthly" | "weekly";
 
@@ -82,6 +83,8 @@ export interface TimelineRowProps {
   employeeId: number;
   name: string;
   team: string | null;
+  /** Capacity in force today; drives the part-time badge in the left panel. */
+  capacity?: EmployeeCapacity | null;
   assignments: TimelineAssignment[];
   vacations?: VacationInfo[];
   occupancy: Record<string, PeriodOccupancy>;

--- a/frontend/src/types/ui.ts
+++ b/frontend/src/types/ui.ts
@@ -42,6 +42,8 @@ export interface DataTableColumn<T> {
   id: string;
   header: string;
   align?: "left" | "right";
+  /** Applied to both the header and body cells, e.g. a fixed width. */
+  className?: string;
   cell: (row: T) => ReactNode;
 }
 


### PR DESCRIPTION
Stacked on #80, so the diff to review is the last two commits.

## Why

Occupancy assumed everyone works a full-time day. Someone contracted for 40h a month read as a quarter busy when their plate was full, and a vacation day always removed eight hours from availability rather than the hours they would actually have worked.

## Model

Capacity lives in a new `employee_capacities` table, one row per period. Rows carry a **start date only** and stay in force until the next one begins. That keeps the timeline gap-free and makes overlaps impossible: a contract change from March is a new row, returning to full time is just another row, and there is nothing to "close". Storing the history is what stops a change made today from rewriting the occupancy of months already closed.

Two capacity types, mirroring the assignment allocation types so both share `calculate_daily_hours`:

| Type | Behaviour |
|---|---|
| `percentage` | fixed daily hours (25% is always 2h/day, so 40–46h per month) |
| `monthly_hours` | fixed monthly total (40h/month is always 40h, so 1.7–2.0h/day) |

These are genuinely different contracts, which is why both exist rather than one being derived from the other.

## Agreed semantics

These were settled before implementation; they are recorded here so the behaviour is documented, not reopened.

- **Capacity sets the denominator of every occupancy figure and the meaning of 100%.** A percentage is a share of that person's own time, so 100% means a full plate whether they work 8h or 2h a day.
- **Moving a percentage assignment between employees changes its hours.** Hours-based allocations are absolute and do not change. Placeholder assignments have no assignee and keep the full-time norm.
- **Days before an employee's earliest period are uncovered and count as zero availability.** That is how an employment start is recorded: move the first period's start date to the joining date.
- **Hours booked against zero availability are reported as overbooked**, not as 0%. The ratio is undefined there, and percentage allocations fall back to the full-time norm on those days, so work planned before someone joins stays visible instead of evaporating.

## Migration

Every existing employee is backfilled with a single full-time period from `1900-01-01`, so behaviour is unchanged until someone edits a contract. Verified up and down against a populated database.

## Frontend

A capacity editor per employee, and part-time markers in the employee list and on the timeline, shown only when the contract is not full time since that is the exception.

It also removes two client-side copies of the full-time constant. Both computed team and per-employee availability as `headcount × working days × 8`, which would have disagreed with the figures the backend returns in the same view. The occupancy filter is one of them, so without this a part-timer at 100% would have been dropped by a "busier than 80%" filter.

Note that this leaves a **pre-existing** disagreement untouched: the filter and the backend handle vacation differently. Logged separately as #81.

## Verification

- 102 backend tests pass, 20 of them new and covering the resolver, the two capacity types, vacation against a part-time contract, a contract change mid-range, and the zero-availability edges.
- Smoke-tested against a populated database in a rolled-back transaction: a 40h/month contract yields exactly `available_hours: 40.0` per month, and the run-length encoded capacity the timeline returns splits correctly on month boundaries.
- Driven in a real browser: adding, editing and deleting a period, the employment-start case, and the recomputed timeline. This caught one bug that type-checking could not, a confirmation dialog rendering behind the dialog that opened it, now an inline confirmation instead.

## Not included

No conversion hints in the assignment form, by request. `docs/data-models.md` and `docs/api-reference.md` are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
